### PR TITLE
Fix pagination after filtering

### DIFF
--- a/build/reactable.js
+++ b/build/reactable.js
@@ -730,14 +730,22 @@ Reactable = (function() {
             // Determine pagination properties and which columns to display
             var itemsPerPage = 0;
             var pagination = false;
+            var numPages;
+            var currentPage = this.state.currentPage;
 
             var currentChildren = filteredChildren;
             if (this.props.itemsPerPage > 0) {
                 itemsPerPage = this.props.itemsPerPage;
+                numPages = Math.ceil(filteredChildren.length / itemsPerPage)
+
+                if (currentPage > numPages - 1) {
+                    currentPage = numPages - 1;
+                }
+
                 pagination = true;
                 currentChildren = filteredChildren.slice(
-                    this.state.currentPage * itemsPerPage,
-                    (this.state.currentPage + 1) * itemsPerPage
+                    currentPage * itemsPerPage,
+                    (currentPage + 1) * itemsPerPage
                 );
             }
 
@@ -758,8 +766,8 @@ Reactable = (function() {
                     pagination === true ?
                         Paginator({
                             colSpan: columns.length, 
-                            numPages: Math.ceil(filteredChildren.length / itemsPerPage), 
-                            currentPage: this.state.currentPage, 
+                            numPages: numPages, 
+                            currentPage: currentPage, 
                             onPageChange: this.onPageChange}) : ''
                     
                 )

--- a/build/tests/reactable_test.js
+++ b/build/tests/reactable_test.js
@@ -890,7 +890,8 @@ describe('Reactable', function() {
                     Reactable.Table({className: "table", id: "table", data: [
                         {'State': 'New York', 'Description': 'this is some text', 'Tag': 'new'},
                         {'State': 'New Mexico', 'Description': 'lorem ipsum', 'Tag': 'old'},
-                        {'State': 'Colorado', 'Description': 'new description that shouldn\'t match filter', 'Tag': 'old'},
+                        {'State': 'Colorado', 'Description': 'new description that shouldn\'t match filter',
+                            'Tag': 'old'},
                         {'State': 'Alaska', 'Description': 'bacon', 'Tag': 'renewed'},
                     ], filterable: ['State', 'Tag'], columns: ['State', 'Description', 'Tag']}),
                     ReactableTestUtils.testNode()
@@ -911,13 +912,14 @@ describe('Reactable', function() {
             });
         });
 
-        describe('filtering and pagination together', function(){
+        context('filtering and pagination together', function(){
             before(function() {
                 React.renderComponent(
                     Reactable.Table({className: "table", id: "table", data: [
                         {'State': 'New York', 'Description': 'this is some text', 'Tag': 'new'},
                         {'State': 'New Mexico', 'Description': 'lorem ipsum', 'Tag': 'old'},
-                        {'State': 'Colorado', 'Description': 'new description that shouldn\'t match filter', 'Tag': 'old'},
+                        {'State': 'Colorado', 'Description': 'new description that shouldn\'t match filter',
+                            'Tag': 'old'},
                         {'State': 'Alaska', 'Description': 'bacon', 'Tag': 'renewed'},
                     ], 
                         filterable: ['State', 'Tag'], 
@@ -929,6 +931,12 @@ describe('Reactable', function() {
 
             after(ReactableTestUtils.resetTestEnvironment);
 
+            afterEach(function() {
+                var $filter = $('#table thead tr.reactable-filterer input.reactable-filter-input');
+                $filter.val('');
+                React.addons.TestUtils.Simulate.keyUp($filter[0]);
+            });
+
             it('updates the pagination links', function() {
                 var $filter = $('#table thead tr.reactable-filterer input.reactable-filter-input');
 
@@ -938,6 +946,28 @@ describe('Reactable', function() {
                 var pageButtons = $('#table tbody.reactable-pagination a.reactable-page-button');
                 expect(pageButtons.length).to.equal(1);
                 expect($(pageButtons[0])).to.have.text('1');
+            });
+
+            it('updates the current page if necessary', function() {
+                var $filter = $('#table thead tr.reactable-filterer input.reactable-filter-input');
+                var $pageButtons = $('#table tbody.reactable-pagination a.reactable-page-button');
+
+                // Go to the last page
+                React.addons.TestUtils.Simulate.click($pageButtons[1])
+
+                // Then filter so that that page doesn't exist anymore
+                $filter.val('colorado');
+                React.addons.TestUtils.Simulate.keyUp($filter[0]);
+
+                ReactableTestUtils.expectRowText(0, [
+                    'Colorado',
+                    "new description that shouldn't match filter",
+                    'old'
+                ]);
+                var activePage = $('#table tbody.reactable-pagination ' +
+                    'a.reactable-page-button.reactable-current-page');
+                expect(activePage.length).to.equal(1);
+                expect(activePage).to.have.text('1');
             });
         });
     });

--- a/src/reactable.jsx
+++ b/src/reactable.jsx
@@ -730,14 +730,22 @@ Reactable = (function() {
             // Determine pagination properties and which columns to display
             var itemsPerPage = 0;
             var pagination = false;
+            var numPages;
+            var currentPage = this.state.currentPage;
 
             var currentChildren = filteredChildren;
             if (this.props.itemsPerPage > 0) {
                 itemsPerPage = this.props.itemsPerPage;
+                numPages = Math.ceil(filteredChildren.length / itemsPerPage)
+
+                if (currentPage > numPages - 1) {
+                    currentPage = numPages - 1;
+                }
+
                 pagination = true;
                 currentChildren = filteredChildren.slice(
-                    this.state.currentPage * itemsPerPage,
-                    (this.state.currentPage + 1) * itemsPerPage
+                    currentPage * itemsPerPage,
+                    (currentPage + 1) * itemsPerPage
                 );
             }
 
@@ -758,8 +766,8 @@ Reactable = (function() {
                     {pagination === true ?
                         <Paginator
                             colSpan={columns.length}
-                            numPages={Math.ceil(filteredChildren.length / itemsPerPage)}
-                            currentPage={this.state.currentPage}
+                            numPages={numPages}
+                            currentPage={currentPage}
                             onPageChange={this.onPageChange}/> : ''
                     }
                 </table>

--- a/test.html
+++ b/test.html
@@ -18,7 +18,16 @@
                     { Name: 'Griffin Smith', Age: '18', HideThis: 'one'},
                     { Age: '23', Name: 'Lee Salminen', HideThis: 'two'},
                     { Age: '28', Position: 'Developer'},
-                ]} columns={['Name', 'Age']}/>,
+                    { Age: '23', Name: 'Lee Salminen', HideThis: 'two'},
+                    { Name: 'Griffin Smith', Age: '18', HideThis: 'one'},
+                    { Age: '28', Position: 'Developer'},
+                    { Name: 'Griffin Smith', Age: '18', HideThis: 'one'},
+                    { Age: '28', Position: 'Developer'},
+                    { Age: '23', Name: 'Lee Salminen', HideThis: 'two'},
+                    { Age: '28', Position: 'Developer'},
+                    { Age: '23', Name: 'Lee Salminen', HideThis: 'two'},
+                    { Name: 'Griffin Smith', Age: '18', HideThis: 'one'},
+                ]} columns={['Name', 'Age']} filterable={['Name']} itemsPerPage={3} />,
                 document.getElementById('test-div')
             );
         </script>

--- a/tests/reactable_test.jsx
+++ b/tests/reactable_test.jsx
@@ -890,7 +890,8 @@ describe('Reactable', function() {
                     <Reactable.Table className="table" id="table" data={[
                         {'State': 'New York', 'Description': 'this is some text', 'Tag': 'new'},
                         {'State': 'New Mexico', 'Description': 'lorem ipsum', 'Tag': 'old'},
-                        {'State': 'Colorado', 'Description': 'new description that shouldn\'t match filter', 'Tag': 'old'},
+                        {'State': 'Colorado', 'Description': 'new description that shouldn\'t match filter',
+                            'Tag': 'old'},
                         {'State': 'Alaska', 'Description': 'bacon', 'Tag': 'renewed'},
                     ]} filterable={['State', 'Tag']} columns={['State', 'Description', 'Tag']}/>,
                     ReactableTestUtils.testNode()
@@ -911,13 +912,14 @@ describe('Reactable', function() {
             });
         });
 
-        describe('filtering and pagination together', function(){
+        context('filtering and pagination together', function(){
             before(function() {
                 React.renderComponent(
                     <Reactable.Table className="table" id="table" data={[
                         {'State': 'New York', 'Description': 'this is some text', 'Tag': 'new'},
                         {'State': 'New Mexico', 'Description': 'lorem ipsum', 'Tag': 'old'},
-                        {'State': 'Colorado', 'Description': 'new description that shouldn\'t match filter', 'Tag': 'old'},
+                        {'State': 'Colorado', 'Description': 'new description that shouldn\'t match filter',
+                            'Tag': 'old'},
                         {'State': 'Alaska', 'Description': 'bacon', 'Tag': 'renewed'},
                     ]}
                         filterable={['State', 'Tag']}
@@ -929,6 +931,12 @@ describe('Reactable', function() {
 
             after(ReactableTestUtils.resetTestEnvironment);
 
+            afterEach(function() {
+                var $filter = $('#table thead tr.reactable-filterer input.reactable-filter-input');
+                $filter.val('');
+                React.addons.TestUtils.Simulate.keyUp($filter[0]);
+            });
+
             it('updates the pagination links', function() {
                 var $filter = $('#table thead tr.reactable-filterer input.reactable-filter-input');
 
@@ -938,6 +946,28 @@ describe('Reactable', function() {
                 var pageButtons = $('#table tbody.reactable-pagination a.reactable-page-button');
                 expect(pageButtons.length).to.equal(1);
                 expect($(pageButtons[0])).to.have.text('1');
+            });
+
+            it('updates the current page if necessary', function() {
+                var $filter = $('#table thead tr.reactable-filterer input.reactable-filter-input');
+                var $pageButtons = $('#table tbody.reactable-pagination a.reactable-page-button');
+
+                // Go to the last page
+                React.addons.TestUtils.Simulate.click($pageButtons[1])
+
+                // Then filter so that that page doesn't exist anymore
+                $filter.val('colorado');
+                React.addons.TestUtils.Simulate.keyUp($filter[0]);
+
+                ReactableTestUtils.expectRowText(0, [
+                    'Colorado',
+                    "new description that shouldn't match filter",
+                    'old'
+                ]);
+                var activePage = $('#table tbody.reactable-pagination ' +
+                    'a.reactable-page-button.reactable-current-page');
+                expect(activePage.length).to.equal(1);
+                expect(activePage).to.have.text('1');
             });
         });
     });


### PR DESCRIPTION
Fix issue where, if the user was on a page that, after filtering,
didn't exist anymore, the user would remain on that page even though it
didn't exist

Fixes #33
