### PR TITLE
Fix bug with re-rendering

### DIFF
--- a/build/reactable.js
+++ b/build/reactable.js
@@ -685,7 +685,7 @@
                 keyB = stringable(keyB) ? keyB.toString() : '';
 
                 // Default sort
-                if (this._sortable[currentSort.column] === 'default') {
+                if (this._sortable[currentSort.column] === undefined || this._sortable[currentSort.column] === 'default') {
 
                     // Reverse direction if we're doing a reverse sort
                     if (keyA < keyB) {

--- a/build/tests/reactable_test.js
+++ b/build/tests/reactable_test.js
@@ -708,8 +708,9 @@ describe('Reactable', function() {
         });
 
         describe('passing `true` to sortable', function() {
+            var component;
             before(function() {
-                React.renderComponent(
+                component = React.renderComponent(
                     Reactable.Table({className: "table", id: "table", data: [
                         { Name: 'Lee Salminen', Age: '23', Position: 'Programmer'},
                         { Name: 'Griffin Smith', Age: '18', Position: 'Engineer'},
@@ -793,6 +794,14 @@ describe('Reactable', function() {
 
                 // Make sure the headers have the right classes
                 expect($(positionHeader)).to.have.class('reactable-header-sort-desc');
+            });
+
+            it('Keeps the same sort after rerendering', function(){
+                expect(function() {component.setProps({update: true})}).to.not.throw(Error);
+
+                ReactableTestUtils.expectRowText(0, ['Lee Salminen', '23', 'Programmer']);
+                ReactableTestUtils.expectRowText(1, ['Griffin Smith', '18', 'Engineer']);
+                ReactableTestUtils.expectRowText(2, ['Ian Zhang', '28', 'Developer']);
             });
         });
 

--- a/src/reactable.jsx
+++ b/src/reactable.jsx
@@ -685,7 +685,7 @@
                 keyB = stringable(keyB) ? keyB.toString() : '';
 
                 // Default sort
-                if (this._sortable[currentSort.column] === 'default') {
+                if (this._sortable[currentSort.column] === undefined || this._sortable[currentSort.column] === 'default') {
 
                     // Reverse direction if we're doing a reverse sort
                     if (keyA < keyB) {

--- a/tests/reactable_test.jsx
+++ b/tests/reactable_test.jsx
@@ -708,8 +708,9 @@ describe('Reactable', function() {
         });
 
         describe('passing `true` to sortable', function() {
+            var component;
             before(function() {
-                React.renderComponent(
+                component = React.renderComponent(
                     <Reactable.Table className="table" id="table" data={[
                         { Name: 'Lee Salminen', Age: '23', Position: 'Programmer'},
                         { Name: 'Griffin Smith', Age: '18', Position: 'Engineer'},
@@ -793,6 +794,14 @@ describe('Reactable', function() {
 
                 // Make sure the headers have the right classes
                 expect($(positionHeader)).to.have.class('reactable-header-sort-desc');
+            });
+
+            it('Keeps the same sort after rerendering', function(){
+                expect(function() {component.setProps({update: true})}).to.not.throw(Error);
+
+                ReactableTestUtils.expectRowText(0, ['Lee Salminen', '23', 'Programmer']);
+                ReactableTestUtils.expectRowText(1, ['Griffin Smith', '18', 'Engineer']);
+                ReactableTestUtils.expectRowText(2, ['Ian Zhang', '28', 'Developer']);
             });
         });
 


### PR DESCRIPTION
I'm using `sortable={true}` and saw an error (Line 703, `this._sortable[currentSort.column]` isn't a function) when I first clicked to sort, then caused my parent to re-rendered my Table.

Because the special handling of `if (this.props.sortable === true)` occurs in render _after_ `sortByCurrentSort` is triggered by `componentWillReceiveProps`, `this._sortable` was an empty object and it was trying to use the custom-sort code path instead of the default.
