### PR TITLE
Pass through html props to rendered Tds

### DIFF
--- a/build/reactable.js
+++ b/build/reactable.js
@@ -305,7 +305,19 @@
 
                 children = children.concat(this.props.columns.map(function(column, i) {
                     if (this.props.data.hasOwnProperty(column.key)) {
-                        return Td({column: column, key: column.key}, this.props.data[column.key]);
+                        var value = this.props.data[column.key];
+                        var props = {};
+
+                        if (
+                            typeof(value) !== 'undefined' &&
+                            value !== null &&
+                            value.__reactableMeta === true
+                        ) {
+                            props = value.props;
+                            value = value.value;
+                        }
+
+                        return Td(Object.assign({column: column, key: column.key}, props), value);
                     } else {
                         return Td({column: column, key: column.key});
                     }
@@ -506,20 +518,24 @@
                         /* if (descendant.type.ConvenienceConstructor === Td) { */
                         if (true) {
                             if (typeof(descendant.props.column) !== 'undefined') {
-                                if (typeof(descendant.props.data) !== 'undefined') {
+                                var value;
 
-                                    childData[descendant.props.column] =
-                                        descendant.props.data;
-                                } else if (
-                                    typeof(descendant.props.children) !== 'undefined'
-                                ) {
-                                    childData[descendant.props.column] =
-                                        descendant.props.children;
+                                if (typeof(descendant.props.data) !== 'undefined') {
+                                    value = descendant.props.data;
+                                } else if (typeof(descendant.props.children) !== 'undefined') {
+                                    value = descendant.props.children;
                                 } else {
                                     console.warn('exports.Td specified without ' +
                                             'a `data` property or children, ' +
                                             'ignoring');
+                                    return;
                                 }
+
+                                childData[descendant.props.column] = {
+                                    value: value,
+                                    props: filterPropsFrom(descendant.props),
+                                    __reactableMeta: true
+                                };
                             } else {
                                 console.warn('exports.Td specified without a ' +
                                         '`column` property, ignoring');

--- a/build/tests/reactable_test.js
+++ b/build/tests/reactable_test.js
@@ -119,46 +119,6 @@ describe('Reactable', function() {
         });
     });
 
-    describe('adding <Tr>s with className to the <Table>', function() {
-        before(function() {
-            React.renderComponent(
-                Reactable.Table({className: "table", id: "table"}, 
-                    Reactable.Tr({className: "rowClass1", data: { Name: 'Griffin Smith', Age: '18'}}), 
-                    Reactable.Tr({className: "rowClass2", data: { Age: '23', Name: 'Lee Salminen'}}), 
-                    Reactable.Tr({className: "rowClass3", data: { Age: '28', Position: 'Developer'}})
-                ),
-                ReactableTestUtils.testNode()
-            );
-        });
-
-        after(ReactableTestUtils.resetTestEnvironment);
-
-        it('renders the table', function() {
-            expect($('table#table.table')).to.exist;
-        });
-
-        it('renders the column headers in the table', function() {
-            var headers = [];
-            $('thead th').each(function() {
-                headers.push($(this).text());
-            });
-
-            expect(headers).to.eql([ 'Name', 'Age', 'Position' ]);
-        });
-
-        it('renders the first row with the correct class name', function() {
-            ReactableTestUtils.expectRowClass(0, 'rowClass1');
-        });
-
-        it('renders the second row with the correct class name', function() {
-            ReactableTestUtils.expectRowClass(1, 'rowClass2');
-        });
-
-        it('renders the third row with the correct class name', function() {
-            ReactableTestUtils.expectRowClass(2, 'rowClass3');
-        });
-    });
-
     describe('adding <Td>s to the <Tr>s', function() {
         context('with only one <Td>', function() {
             before(function() {
@@ -311,6 +271,84 @@ describe('Reactable', function() {
                 ReactableTestUtils.expectRowText(2, ['', '28', 'Developer']);
             });
         })
+    });
+
+    describe('passing through HTML props', function() {
+        describe('adding <Tr>s with className to the <Table>', function() {
+            before(function() {
+                React.renderComponent(
+                    Reactable.Table({className: "table", id: "table"}, 
+                        Reactable.Tr({className: "rowClass1", data: { Name: 'Griffin Smith', Age: '18'}}), 
+                        Reactable.Tr({className: "rowClass2", data: { Age: '23', Name: 'Lee Salminen'}}), 
+                        Reactable.Tr({className: "rowClass3", data: { Age: '28', Position: 'Developer'}})
+                    ),
+                    ReactableTestUtils.testNode()
+                );
+            });
+
+            after(ReactableTestUtils.resetTestEnvironment);
+
+            it('renders the table', function() {
+                expect($('table#table.table')).to.exist;
+            });
+
+            it('renders the column headers in the table', function() {
+                var headers = [];
+                $('thead th').each(function() {
+                    headers.push($(this).text());
+                });
+
+                expect(headers).to.eql([ 'Name', 'Age', 'Position' ]);
+            });
+
+            it('renders the first row with the correct class name', function() {
+                ReactableTestUtils.expectRowClass(0, 'rowClass1');
+            });
+
+            it('renders the second row with the correct class name', function() {
+                ReactableTestUtils.expectRowClass(1, 'rowClass2');
+            });
+
+            it('renders the third row with the correct class name', function() {
+                ReactableTestUtils.expectRowClass(2, 'rowClass3');
+            });
+        });
+
+        describe('adding <Td>s with classNames to the <Table>', function() {
+            before(function () {
+                React.renderComponent(
+                    Reactable.Table({className: "table", id: "table"}, 
+                        Reactable.Tr(null, 
+                            Reactable.Td({column: "Name", className: "name-1"}, "Griffin Smith"), 
+                            Reactable.Td({column: "Age"}, "18")
+                        ), 
+                        Reactable.Tr(null, 
+                            Reactable.Td({column: "Name", className: "name-2"}, "Lee Salminen"), 
+                            Reactable.Td({column: "Age"}, "23")
+                        ), 
+                        Reactable.Tr(null, 
+                            Reactable.Td({column: "Position", className: "position"}, "Developer"), 
+                            Reactable.Td({column: "Age"}, "28")
+                        )
+                    ),
+                    ReactableTestUtils.testNode()
+                );
+            });
+
+            after(ReactableTestUtils.resetTestEnvironment);
+
+            it('renders the first column with the correct class name', function() {
+                expect($('td.name-1')).to.have.text('Griffin Smith');
+            });
+
+            it('renders the second column with the correct class name', function() {
+                expect($('td.name-2')).to.have.text('Lee Salminen');
+            });
+
+            it('renders the third column with the correct class name', function() {
+                expect($('td.position')).to.have.text('Developer');
+            });
+        });
     });
 
     describe('specifying an array of columns', function() {

--- a/src/reactable.jsx
+++ b/src/reactable.jsx
@@ -305,7 +305,19 @@
 
                 children = children.concat(this.props.columns.map(function(column, i) {
                     if (this.props.data.hasOwnProperty(column.key)) {
-                        return <Td column={column} key={column.key}>{this.props.data[column.key]}</Td>;
+                        var value = this.props.data[column.key];
+                        var props = {};
+
+                        if (
+                            typeof(value) !== 'undefined' &&
+                            value !== null &&
+                            value.__reactableMeta === true
+                        ) {
+                            props = value.props;
+                            value = value.value;
+                        }
+
+                        return <Td column={column} key={column.key} {...props}>{value}</Td>;
                     } else {
                         return <Td column={column} key={column.key} />;
                     }
@@ -506,20 +518,24 @@
                         /* if (descendant.type.ConvenienceConstructor === Td) { */
                         if (true) {
                             if (typeof(descendant.props.column) !== 'undefined') {
-                                if (typeof(descendant.props.data) !== 'undefined') {
+                                var value;
 
-                                    childData[descendant.props.column] =
-                                        descendant.props.data;
-                                } else if (
-                                    typeof(descendant.props.children) !== 'undefined'
-                                ) {
-                                    childData[descendant.props.column] =
-                                        descendant.props.children;
+                                if (typeof(descendant.props.data) !== 'undefined') {
+                                    value = descendant.props.data;
+                                } else if (typeof(descendant.props.children) !== 'undefined') {
+                                    value = descendant.props.children;
                                 } else {
                                     console.warn('exports.Td specified without ' +
                                             'a `data` property or children, ' +
                                             'ignoring');
+                                    return;
                                 }
+
+                                childData[descendant.props.column] = {
+                                    value: value,
+                                    props: filterPropsFrom(descendant.props),
+                                    __reactableMeta: true
+                                };
                             } else {
                                 console.warn('exports.Td specified without a ' +
                                         '`column` property, ignoring');

--- a/tests/reactable_test.jsx
+++ b/tests/reactable_test.jsx
@@ -119,46 +119,6 @@ describe('Reactable', function() {
         });
     });
 
-    describe('adding <Tr>s with className to the <Table>', function() {
-        before(function() {
-            React.renderComponent(
-                <Reactable.Table className="table" id="table">
-                    <Reactable.Tr className="rowClass1" data={{ Name: 'Griffin Smith', Age: '18'}}/>
-                    <Reactable.Tr className="rowClass2" data={{ Age: '23', Name: 'Lee Salminen'}}/>
-                    <Reactable.Tr className="rowClass3" data={{ Age: '28', Position: 'Developer'}}/>
-                </Reactable.Table>,
-                ReactableTestUtils.testNode()
-            );
-        });
-
-        after(ReactableTestUtils.resetTestEnvironment);
-
-        it('renders the table', function() {
-            expect($('table#table.table')).to.exist;
-        });
-
-        it('renders the column headers in the table', function() {
-            var headers = [];
-            $('thead th').each(function() {
-                headers.push($(this).text());
-            });
-
-            expect(headers).to.eql([ 'Name', 'Age', 'Position' ]);
-        });
-
-        it('renders the first row with the correct class name', function() {
-            ReactableTestUtils.expectRowClass(0, 'rowClass1');
-        });
-
-        it('renders the second row with the correct class name', function() {
-            ReactableTestUtils.expectRowClass(1, 'rowClass2');
-        });
-
-        it('renders the third row with the correct class name', function() {
-            ReactableTestUtils.expectRowClass(2, 'rowClass3');
-        });
-    });
-
     describe('adding <Td>s to the <Tr>s', function() {
         context('with only one <Td>', function() {
             before(function() {
@@ -311,6 +271,84 @@ describe('Reactable', function() {
                 ReactableTestUtils.expectRowText(2, ['', '28', 'Developer']);
             });
         })
+    });
+
+    describe('passing through HTML props', function() {
+        describe('adding <Tr>s with className to the <Table>', function() {
+            before(function() {
+                React.renderComponent(
+                    <Reactable.Table className="table" id="table">
+                        <Reactable.Tr className="rowClass1" data={{ Name: 'Griffin Smith', Age: '18'}}/>
+                        <Reactable.Tr className="rowClass2" data={{ Age: '23', Name: 'Lee Salminen'}}/>
+                        <Reactable.Tr className="rowClass3" data={{ Age: '28', Position: 'Developer'}}/>
+                    </Reactable.Table>,
+                    ReactableTestUtils.testNode()
+                );
+            });
+
+            after(ReactableTestUtils.resetTestEnvironment);
+
+            it('renders the table', function() {
+                expect($('table#table.table')).to.exist;
+            });
+
+            it('renders the column headers in the table', function() {
+                var headers = [];
+                $('thead th').each(function() {
+                    headers.push($(this).text());
+                });
+
+                expect(headers).to.eql([ 'Name', 'Age', 'Position' ]);
+            });
+
+            it('renders the first row with the correct class name', function() {
+                ReactableTestUtils.expectRowClass(0, 'rowClass1');
+            });
+
+            it('renders the second row with the correct class name', function() {
+                ReactableTestUtils.expectRowClass(1, 'rowClass2');
+            });
+
+            it('renders the third row with the correct class name', function() {
+                ReactableTestUtils.expectRowClass(2, 'rowClass3');
+            });
+        });
+
+        describe('adding <Td>s with classNames to the <Table>', function() {
+            before(function () {
+                React.renderComponent(
+                    <Reactable.Table className="table" id="table">
+                        <Reactable.Tr>
+                            <Reactable.Td column="Name" className="name-1">Griffin Smith</Reactable.Td>
+                            <Reactable.Td column="Age">18</Reactable.Td>
+                        </Reactable.Tr>
+                        <Reactable.Tr>
+                            <Reactable.Td column="Name" className="name-2">Lee Salminen</Reactable.Td>
+                            <Reactable.Td column="Age">23</Reactable.Td>
+                        </Reactable.Tr>
+                        <Reactable.Tr>
+                            <Reactable.Td column="Position" className="position">Developer</Reactable.Td>
+                            <Reactable.Td column="Age">28</Reactable.Td>
+                        </Reactable.Tr>
+                    </Reactable.Table>,
+                    ReactableTestUtils.testNode()
+                );
+            });
+
+            after(ReactableTestUtils.resetTestEnvironment);
+
+            it('renders the first column with the correct class name', function() {
+                expect($('td.name-1')).to.have.text('Griffin Smith');
+            });
+
+            it('renders the second column with the correct class name', function() {
+                expect($('td.name-2')).to.have.text('Lee Salminen');
+            });
+
+            it('renders the third column with the correct class name', function() {
+                expect($('td.position')).to.have.text('Developer');
+            });
+        });
     });
 
     describe('specifying an array of columns', function() {


### PR DESCRIPTION
Using the same strategy as in #103 (a meta-object containing the actual
value, the props, and `__reactableMeta: true`), pass through HTML props
to rendered Tds.

Fixes #107