### PR TITLE
Sorting broken when specifying table data with Trs and Tds

### DIFF
--- a/build/tests/reactable_test.js
+++ b/build/tests/reactable_test.js
@@ -1026,6 +1026,72 @@ describe('Reactable', function() {
             });
         });
 
+        describe('numeric sort with Tr and Td specified', function(){
+            before(function() {
+                React.renderComponent(
+                    Reactable.Table({
+                        className: "table", 
+                        id: "table", 
+                        columns: [{ key: 'Count', sortable: Reactable.Sort.Numeric }]
+                    }, 
+                        Reactable.Tr(null, 
+                            Reactable.Td({column: "Count"}, 
+                                "23"
+                            )
+                        ), 
+                        Reactable.Tr(null, 
+                            Reactable.Td({column: "Count"}, 
+                                "18"
+                            )
+                        ), 
+                        Reactable.Tr(null, 
+                            Reactable.Td({column: "Count"}, 
+                                "28"
+                            )
+                        ), 
+                        Reactable.Tr(null, 
+                            Reactable.Td({column: "Count"}, 
+                                "1.23"
+                            )
+                        ), 
+                        Reactable.Tr(null, 
+                            Reactable.Td({column: "Count"}, 
+                                "a"
+                            )
+                        ), 
+                        Reactable.Tr(null, 
+                            Reactable.Td({column: "Count"}, 
+                                "z"
+                            )
+                        ), 
+                        Reactable.Tr(null, 
+                            Reactable.Td({column: "Count"}, 
+                                "123"
+                            )
+                        )
+                    ),
+                    ReactableTestUtils.testNode()
+                );
+            });
+
+            after(function() {
+                ReactableTestUtils.resetTestEnvironment();
+            });
+
+            it('sorts columns numerically', function(){
+                var sortHeader = $('#table thead tr.reactable-column-header th')[0];
+                ReactTestUtils.Simulate.click(sortHeader);
+
+                ReactableTestUtils.expectRowText(0, ['1.23']);
+                ReactableTestUtils.expectRowText(1, ['18']);
+                ReactableTestUtils.expectRowText(2, ['23']);
+                ReactableTestUtils.expectRowText(3, ['28']);
+                ReactableTestUtils.expectRowText(4, ['123']);
+                ReactableTestUtils.expectRowText(5, ['a']);
+                ReactableTestUtils.expectRowText(6, ['z']);
+            });
+        });
+
         describe('currency sort', function(){
             before(function() {
                 React.renderComponent(

--- a/tests/reactable_test.jsx
+++ b/tests/reactable_test.jsx
@@ -1026,6 +1026,72 @@ describe('Reactable', function() {
             });
         });
 
+        describe('numeric sort with Tr and Td specified', function(){
+            before(function() {
+                React.renderComponent(
+                    <Reactable.Table
+                        className="table"
+                        id="table"
+                        columns={[{ key: 'Count', sortable: Reactable.Sort.Numeric }]}
+                    >
+                        <Reactable.Tr>
+                            <Reactable.Td column='Count'>
+                                23
+                            </Reactable.Td>
+                        </Reactable.Tr>
+                        <Reactable.Tr>
+                            <Reactable.Td column='Count'>
+                                18
+                            </Reactable.Td>
+                        </Reactable.Tr>
+                        <Reactable.Tr>
+                            <Reactable.Td column='Count'>
+                                28
+                            </Reactable.Td>
+                        </Reactable.Tr>
+                        <Reactable.Tr>
+                            <Reactable.Td column='Count'>
+                                1.23
+                            </Reactable.Td>
+                        </Reactable.Tr>
+                        <Reactable.Tr>
+                            <Reactable.Td column='Count'>
+                                a
+                            </Reactable.Td>
+                        </Reactable.Tr>
+                        <Reactable.Tr>
+                            <Reactable.Td column='Count'>
+                                z
+                            </Reactable.Td>
+                        </Reactable.Tr>
+                        <Reactable.Tr>
+                            <Reactable.Td column='Count'>
+                                123
+                            </Reactable.Td>
+                        </Reactable.Tr>
+                    </Reactable.Table>,
+                    ReactableTestUtils.testNode()
+                );
+            });
+
+            after(function() {
+                ReactableTestUtils.resetTestEnvironment();
+            });
+
+            it('sorts columns numerically', function(){
+                var sortHeader = $('#table thead tr.reactable-column-header th')[0];
+                ReactTestUtils.Simulate.click(sortHeader);
+
+                ReactableTestUtils.expectRowText(0, ['1.23']);
+                ReactableTestUtils.expectRowText(1, ['18']);
+                ReactableTestUtils.expectRowText(2, ['23']);
+                ReactableTestUtils.expectRowText(3, ['28']);
+                ReactableTestUtils.expectRowText(4, ['123']);
+                ReactableTestUtils.expectRowText(5, ['a']);
+                ReactableTestUtils.expectRowText(6, ['z']);
+            });
+        });
+
         describe('currency sort', function(){
             before(function() {
                 React.renderComponent(


### PR DESCRIPTION
https://github.com/glittershark/reactable/blob/master/src/reactable.jsx#L709
```
this.data.sort(function(a, b){
    var keyA = a[currentSort.column];
    keyA = stringable(keyA) ? keyA.toString() : '';
    var keyB = b[currentSort.column];
    keyB = stringable(keyB) ? keyB.toString() : '';

    ...
```

When specifying table data manually with Tds, `a` and `b` have properties `data` and `props`, so `a[currentSort.column]` and `b[currentSort.column]` are undefined.

Looks like `data` will either have a value or an object with a `value` property.