### PR TITLE
Allow to specify default tr props

### DIFF
--- a/build/reactable.js
+++ b/build/reactable.js
@@ -782,7 +782,7 @@
                 // Build up the columns array
                 children = children.concat(this.data.map(function(rawData, i) {
                     var data = rawData;
-                    var props = {};
+                    var props = this.props.defaultTrProps || {};
                     if (rawData.__reactableMeta === true) {
                         data = rawData.data;
                         props = rawData.props;

--- a/src/reactable.jsx
+++ b/src/reactable.jsx
@@ -782,7 +782,7 @@
                 // Build up the columns array
                 children = children.concat(this.data.map(function(rawData, i) {
                     var data = rawData;
-                    var props = {};
+                    var props = this.props.defaultTrProps || {};
                     if (rawData.__reactableMeta === true) {
                         data = rawData.data;
                         props = rawData.props;


### PR DESCRIPTION
Specify default TR properties:

solves #110

```js
var defaultTrProps = {
    cssClass: 'table__tr',
    onClick: this.handleTrClick
};
<ReactTable sortable={true} columns={columns} data={data} defaultTrProps={defaultTrProps} />

```