### PR TITLE
Added ability to sort using custom value prop

### DIFF
--- a/build/reactable.js
+++ b/build/reactable.js
@@ -927,7 +927,8 @@
                 value !== null &&
                     value.__reactableMeta === true
         ) {
-            value = value.value;
+            value = (typeof(value.props.value) !== 'undefined' && value.props.value !== null) ?
+                value.props.value : value.value;
         }
 
         if (stringable(value)) {

--- a/build/tests/reactable_test.js
+++ b/build/tests/reactable_test.js
@@ -1077,6 +1077,57 @@ describe('Reactable', function() {
             });
         });
 
+        describe('numeric sort with Tr and Td specified and custom value', function(){
+            before(function() {
+                React.renderComponent(
+                    Reactable.Table({
+                        className: "table", 
+                        id: "table", 
+                        columns: [{ key: 'Count', sortable: Reactable.Sort.Numeric }]}, 
+                        Reactable.Tr(null, 
+                            Reactable.Td({column: "Count", value: 23}, "twenty-three")
+                        ), 
+                        Reactable.Tr(null, 
+                            Reactable.Td({column: "Count", value: 18}, "eighteen")
+                        ), 
+                        Reactable.Tr(null, 
+                            Reactable.Td({column: "Count", value: 28}, "twenty-eight")
+                        ), 
+                        Reactable.Tr(null, 
+                            Reactable.Td({column: "Count", value: 1.23}, "one point two three")
+                        ), 
+                        Reactable.Tr(null, 
+                            Reactable.Td({column: "Count", value: "a"}, "a")
+                        ), 
+                        Reactable.Tr(null, 
+                            Reactable.Td({column: "Count", value: "z"}, "z")
+                        ), 
+                        Reactable.Tr(null, 
+                            Reactable.Td({column: "Count", value: 123}, "one hundred twenty-three")
+                        )
+                    ),
+                    ReactableTestUtils.testNode()
+                );
+            });
+
+            after(function() {
+                ReactableTestUtils.resetTestEnvironment();
+            });
+
+            it('sorts columns numerically', function(){
+                var sortHeader = $('#table thead tr.reactable-column-header th')[0];
+                ReactTestUtils.Simulate.click(sortHeader);
+
+                ReactableTestUtils.expectRowText(0, ['one point two three']);
+                ReactableTestUtils.expectRowText(1, ['eighteen']);
+                ReactableTestUtils.expectRowText(2, ['twenty-three']);
+                ReactableTestUtils.expectRowText(3, ['twenty-eight']);
+                ReactableTestUtils.expectRowText(4, ['one hundred twenty-three']);
+                ReactableTestUtils.expectRowText(5, ['a']);
+                ReactableTestUtils.expectRowText(6, ['z']);
+            });
+        });
+
         describe('currency sort', function(){
             before(function() {
                 React.renderComponent(

--- a/src/reactable.jsx
+++ b/src/reactable.jsx
@@ -927,7 +927,8 @@
                 value !== null &&
                     value.__reactableMeta === true
         ) {
-            value = value.value;
+            value = (typeof(value.props.value) !== 'undefined' && value.props.value !== null) ?
+                value.props.value : value.value;
         }
 
         if (stringable(value)) {

--- a/tests/reactable_test.jsx
+++ b/tests/reactable_test.jsx
@@ -1077,6 +1077,57 @@ describe('Reactable', function() {
             });
         });
 
+        describe('numeric sort with Tr and Td specified and custom value', function(){
+            before(function() {
+                React.renderComponent(
+                    <Reactable.Table
+                        className="table"
+                        id="table"
+                        columns={[{ key: 'Count', sortable: Reactable.Sort.Numeric }]}>
+                        <Reactable.Tr>
+                            <Reactable.Td column='Count' value={23}>twenty-three</Reactable.Td>
+                        </Reactable.Tr>
+                        <Reactable.Tr>
+                            <Reactable.Td column='Count' value={18}>eighteen</Reactable.Td>
+                        </Reactable.Tr>
+                        <Reactable.Tr>
+                            <Reactable.Td column='Count' value={28}>twenty-eight</Reactable.Td>
+                        </Reactable.Tr>
+                        <Reactable.Tr>
+                            <Reactable.Td column='Count' value={1.23}>one point two three</Reactable.Td>
+                        </Reactable.Tr>
+                        <Reactable.Tr>
+                            <Reactable.Td column='Count' value='a'>a</Reactable.Td>
+                        </Reactable.Tr>
+                        <Reactable.Tr>
+                            <Reactable.Td column='Count' value='z'>z</Reactable.Td>
+                        </Reactable.Tr>
+                        <Reactable.Tr>
+                            <Reactable.Td column='Count' value={123}>one hundred twenty-three</Reactable.Td>
+                        </Reactable.Tr>
+                    </Reactable.Table>,
+                    ReactableTestUtils.testNode()
+                );
+            });
+
+            after(function() {
+                ReactableTestUtils.resetTestEnvironment();
+            });
+
+            it('sorts columns numerically', function(){
+                var sortHeader = $('#table thead tr.reactable-column-header th')[0];
+                ReactTestUtils.Simulate.click(sortHeader);
+
+                ReactableTestUtils.expectRowText(0, ['one point two three']);
+                ReactableTestUtils.expectRowText(1, ['eighteen']);
+                ReactableTestUtils.expectRowText(2, ['twenty-three']);
+                ReactableTestUtils.expectRowText(3, ['twenty-eight']);
+                ReactableTestUtils.expectRowText(4, ['one hundred twenty-three']);
+                ReactableTestUtils.expectRowText(5, ['a']);
+                ReactableTestUtils.expectRowText(6, ['z']);
+            });
+        });
+
         describe('currency sort', function(){
             before(function() {
                 React.renderComponent(


### PR DESCRIPTION
If cells contain custom data, you can pass in a `value` prop which will be used for sorting.

Fixes: https://github.com/glittershark/reactable/issues/87