### PR TITLE
Simplify CaseInsensitive and add NumericInteger sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ We've pre-built some sort functions for you.
   12:05 PM)
 - `Currency` will sort USD format (e.g. $1,000.00)
 - `Numeric` will parse integer-like strings as integers (e.g. "1")
+- `NumericInteger` will parse integer strings (use `Numeric` if you might have floats)
 
 To specify a custom sort function, use the following structure for the column
 object:

--- a/build/reactable.js
+++ b/build/reactable.js
@@ -227,18 +227,7 @@
         },
 
         CaseInsensitive: function(a, b) {
-            var valA = a.toLowerCase();
-            var valB = b.toLowerCase();
-
-            if(valA > valB) {
-                return 1;
-            }
-
-            if(valB > valA) {
-                return -1;
-            }
-
-            return 0;
+            return a.toLowerCase().localeCompare(b.toLowerCase());
         }
     };
 

--- a/build/reactable.js
+++ b/build/reactable.js
@@ -189,6 +189,14 @@
             return 0;
         },
 
+        NumericInteger: function(a, b) {
+          if (isNaN(a) || isNaN(b)) {
+            return a > b ? 1 : -1;
+          }
+
+          return a - b;
+        },
+
         Currency: function(a, b) {
             // Parse out dollar signs, then do a regular numeric sort
             // TODO: handle non-American currency

--- a/build/tests/reactable_test.js
+++ b/build/tests/reactable_test.js
@@ -991,38 +991,40 @@ describe('Reactable', function() {
             });
         });
 
-        describe('numeric sort', function(){
-            before(function() {
-                React.renderComponent(
-                    Reactable.Table({className: "table", id: "table", data: [
-                        { Count: '23'},
-                        { Count: '18'},
-                        { Count: '28'},
-                        { Count: '1.23'},
-                        { Count: 'a'},
-                        { Count: 'z'},
-                        { Count: '123'}
-                    ], 
-                    columns: [{ key: 'Count', sortable: Reactable.Sort.Numeric }]}),
-                    ReactableTestUtils.testNode()
-                );
-            });
+        [Reactable.Sort.Numeric, Reactable.Sort.NumericInteger].forEach(function(method) {
+            describe('numeric sort', function(){
+                before(function() {
+                    React.renderComponent(
+                        Reactable.Table({className: "table", id: "table", data: [
+                            { Count: '23'},
+                            { Count: '18'},
+                            { Count: '28'},
+                            { Count: '1.23'},
+                            { Count: 'a'},
+                            { Count: 'z'},
+                            { Count: '123'}
+                        ], 
+                        columns: [{ key: 'Count', sortable: method }]}),
+                        ReactableTestUtils.testNode()
+                    );
+                });
 
-            after(function() {
-                ReactableTestUtils.resetTestEnvironment();
-            });
+                after(function() {
+                    ReactableTestUtils.resetTestEnvironment();
+                });
 
-            it('sorts columns numerically', function(){
-                var sortHeader = $('#table thead tr.reactable-column-header th')[0];
-                ReactTestUtils.Simulate.click(sortHeader);
+                it('sorts columns numerically', function(){
+                    var sortHeader = $('#table thead tr.reactable-column-header th')[0];
+                    ReactTestUtils.Simulate.click(sortHeader);
 
-                ReactableTestUtils.expectRowText(0, ['1.23']);
-                ReactableTestUtils.expectRowText(1, ['18']);
-                ReactableTestUtils.expectRowText(2, ['23']);
-                ReactableTestUtils.expectRowText(3, ['28']);
-                ReactableTestUtils.expectRowText(4, ['123']);
-                ReactableTestUtils.expectRowText(5, ['a']);
-                ReactableTestUtils.expectRowText(6, ['z']);
+                    ReactableTestUtils.expectRowText(0, ['1.23']);
+                    ReactableTestUtils.expectRowText(1, ['18']);
+                    ReactableTestUtils.expectRowText(2, ['23']);
+                    ReactableTestUtils.expectRowText(3, ['28']);
+                    ReactableTestUtils.expectRowText(4, ['123']);
+                    ReactableTestUtils.expectRowText(5, ['a']);
+                    ReactableTestUtils.expectRowText(6, ['z']);
+                });
             });
         });
 

--- a/src/reactable.jsx
+++ b/src/reactable.jsx
@@ -227,18 +227,7 @@
         },
 
         CaseInsensitive: function(a, b) {
-            var valA = a.toLowerCase();
-            var valB = b.toLowerCase();
-
-            if(valA > valB) {
-                return 1;
-            }
-
-            if(valB > valA) {
-                return -1;
-            }
-
-            return 0;
+            return a.toLowerCase().localeCompare(b.toLowerCase());
         }
     };
 

--- a/src/reactable.jsx
+++ b/src/reactable.jsx
@@ -189,6 +189,14 @@
             return 0;
         },
 
+        NumericInteger: function(a, b) {
+          if (isNaN(a) || isNaN(b)) {
+            return a > b ? 1 : -1;
+          }
+
+          return a - b;
+        },
+
         Currency: function(a, b) {
             // Parse out dollar signs, then do a regular numeric sort
             // TODO: handle non-American currency

--- a/tests/reactable_test.jsx
+++ b/tests/reactable_test.jsx
@@ -991,38 +991,40 @@ describe('Reactable', function() {
             });
         });
 
-        describe('numeric sort', function(){
-            before(function() {
-                React.renderComponent(
-                    <Reactable.Table className="table" id="table" data={[
-                        { Count: '23'},
-                        { Count: '18'},
-                        { Count: '28'},
-                        { Count: '1.23'},
-                        { Count: 'a'},
-                        { Count: 'z'},
-                        { Count: '123'}
-                    ]}
-                    columns={[{ key: 'Count', sortable: Reactable.Sort.Numeric }]} />,
-                    ReactableTestUtils.testNode()
-                );
-            });
+        [Reactable.Sort.Numeric, Reactable.Sort.NumericInteger].forEach(function(method) {
+            describe('numeric sort', function(){
+                before(function() {
+                    React.renderComponent(
+                        <Reactable.Table className="table" id="table" data={[
+                            { Count: '23'},
+                            { Count: '18'},
+                            { Count: '28'},
+                            { Count: '1.23'},
+                            { Count: 'a'},
+                            { Count: 'z'},
+                            { Count: '123'}
+                        ]}
+                        columns={[{ key: 'Count', sortable: method }]} />,
+                        ReactableTestUtils.testNode()
+                    );
+                });
 
-            after(function() {
-                ReactableTestUtils.resetTestEnvironment();
-            });
+                after(function() {
+                    ReactableTestUtils.resetTestEnvironment();
+                });
 
-            it('sorts columns numerically', function(){
-                var sortHeader = $('#table thead tr.reactable-column-header th')[0];
-                ReactTestUtils.Simulate.click(sortHeader);
+                it('sorts columns numerically', function(){
+                    var sortHeader = $('#table thead tr.reactable-column-header th')[0];
+                    ReactTestUtils.Simulate.click(sortHeader);
 
-                ReactableTestUtils.expectRowText(0, ['1.23']);
-                ReactableTestUtils.expectRowText(1, ['18']);
-                ReactableTestUtils.expectRowText(2, ['23']);
-                ReactableTestUtils.expectRowText(3, ['28']);
-                ReactableTestUtils.expectRowText(4, ['123']);
-                ReactableTestUtils.expectRowText(5, ['a']);
-                ReactableTestUtils.expectRowText(6, ['z']);
+                    ReactableTestUtils.expectRowText(0, ['1.23']);
+                    ReactableTestUtils.expectRowText(1, ['18']);
+                    ReactableTestUtils.expectRowText(2, ['23']);
+                    ReactableTestUtils.expectRowText(3, ['28']);
+                    ReactableTestUtils.expectRowText(4, ['123']);
+                    ReactableTestUtils.expectRowText(5, ['a']);
+                    ReactableTestUtils.expectRowText(6, ['z']);
+                });
             });
         });
 


### PR DESCRIPTION
`CaseInsensitive`
This should do the same thing but doesn't require the temporary variables -- it seems to be a little bit faster with 50,000 rows.

`NumericInteger`
Definitely slightly faster than `Numeric` on a list of 50,000 integers (I'm testing with timestamps).