### PR TITLE
Fix filtering broken when specifying table data with Trs and Tds

### DIFF
--- a/src/reactable.jsx
+++ b/src/reactable.jsx
@@ -686,7 +686,7 @@
 
                     if (
                         typeof(data[filterColumn]) !== 'undefined' &&
-                            data[filterColumn].toString().toLowerCase().indexOf(filter) > -1
+                            extractDataFrom(data, filterColumn).toString().toLowerCase().indexOf(filter) > -1
                     ) {
                         matchedChildren.push(children[i]);
                         break;


### PR DESCRIPTION
Replace `data[filterColumn]` with `extractDataFrom(data, filterColumn)` when applying a filter.