### PR TITLE
Allow for user-defined Thead elements

### DIFF
--- a/build/reactable.js
+++ b/build/reactable.js
@@ -362,7 +362,7 @@
 
                 Ths.push(
                     React.createElement(Th, {className: sortClass, key: index, onClick: this.handleClickTh.bind(this, column)}, 
-                        column.label
+                        column.label || column
                     )
                 );
             }
@@ -759,15 +759,35 @@
         },
         render: function() {
             var children = [];
-            var columns;
+            var columns = [];
             var userColumnsSpecified = false;
 
             if (
                 this.props.children &&
                     this.props.children.length > 0 &&
-                        this.props.children[0].type.ConvenienceConstructor === Thead
+                        // @todo get the type of ReactElement
+                        // Seems as if you can only access .contructor.displayName from
+                        // within a CompositeComponent
+                        // this.props.children[0].type.ConvenienceConstructor === Thead
+                        typeof this.props.children[0].props.displayName === 'string' && this.props.children[0].props.displayName.toLowerCase() === 'thead'
             ) {
-                columns = this.props.children[0].getColumns();
+                // Remove thead row from data so it doesn't get inserted into the body
+                if (this.data[0].props && typeof this.data[0].props.displayName === 'string' && this.data[0].props.displayName.toLowerCase() === 'thead') {
+                    this.data.splice(0, 1);
+                }
+                // columns = this.props.children[0].getColumns();
+                // Work around to get Thead > Tr > Th column names
+                if (this.props.children[0].props.children && this.props.children[0].props.children.props.children.length) {
+                    columns = this.props.children[0].props.children.props.children.map(function(child) {
+                        if (child.props.children instanceof Unsafe) {
+                            return {
+                                key: child.props.column,
+                                label: child.props.children
+                            };
+                        }
+                        return child.props.column;
+                    });
+                }
             } else {
                 columns = this.props.columns || [];
             }

--- a/build/reactable.js
+++ b/build/reactable.js
@@ -345,6 +345,7 @@
             for (var index = 0; index < this.props.columns.length; index++) {
                 var column = this.props.columns[index];
                 var sortClass = '';
+                var label = column.label || column;
 
                 if (this.props.sortableColumns[column.key]) {
                     sortClass += 'reactable-header-sortable ';
@@ -362,7 +363,7 @@
 
                 Ths.push(
                     React.createElement(Th, {className: sortClass, key: index, onClick: this.handleClickTh.bind(this, column)}, 
-                        column.label || column
+                        label
                     )
                 );
             }
@@ -769,15 +770,18 @@
                         // Seems as if you can only access .contructor.displayName from
                         // within a CompositeComponent
                         // this.props.children[0].type.ConvenienceConstructor === Thead
-                        typeof this.props.children[0].props.displayName === 'string' && this.props.children[0].props.displayName.toLowerCase() === 'thead'
+                        typeof this.props.children[0].props.displayName === 'string' && 
+                        this.props.children[0].props.displayName.toLowerCase() === 'thead'
             ) {
                 // Remove thead row from data so it doesn't get inserted into the body
-                if (this.data[0].props && typeof this.data[0].props.displayName === 'string' && this.data[0].props.displayName.toLowerCase() === 'thead') {
+                if (this.data[0].props && typeof this.data[0].props.displayName === 'string' &&
+                    this.data[0].props.displayName.toLowerCase() === 'thead') {
                     this.data.splice(0, 1);
                 }
                 // columns = this.props.children[0].getColumns();
                 // Work around to get Thead > Tr > Th column names
-                if (this.props.children[0].props.children && this.props.children[0].props.children.props.children.length) {
+                if (this.props.children[0].props.children &&
+                    this.props.children[0].props.children.props.children.length) {
                     columns = this.props.children[0].props.children.props.children.map(function(child) {
                         if (child.props.children instanceof Unsafe) {
                             return {

--- a/src/reactable.jsx
+++ b/src/reactable.jsx
@@ -759,15 +759,29 @@
         },
         render: function() {
             var children = [];
-            var columns;
+            var columns = [];
             var userColumnsSpecified = false;
 
             if (
                 this.props.children &&
                     this.props.children.length > 0 &&
-                        this.props.children[0].type.ConvenienceConstructor === Thead
+                        // @todo get the type of ReactElement
+                        // Seems as if you can only access .contructor.displayName from
+                        // within a CompositeComponent
+                        // this.props.children[0].type.ConvenienceConstructor === Thead
+                        typeof this.props.children[0].props.displayName === 'string' && this.props.children[0].props.displayName.toLowerCase() === 'thead'
             ) {
-                columns = this.props.children[0].getColumns();
+                // Remove thead row from data so it doesn't get inserted into the body
+                if (this.data[0].props && typeof this.data[0].props.displayName === 'string' && this.data[0].props.displayName.toLowerCase() === 'thead') {
+                    this.data.splice(0, 1);
+                }
+                // columns = this.props.children[0].getColumns();
+                // Work around to get Thead > Tr > Th column names
+                if (this.props.children[0].props.children && this.props.children[0].props.children.props.children.length) {
+                    columns = this.props.children[0].props.children.props.children.map(function(child) {
+                        return child.props.column;
+                    });
+                }
             } else {
                 columns = this.props.columns || [];
             }

--- a/src/reactable.jsx
+++ b/src/reactable.jsx
@@ -362,7 +362,7 @@
 
                 Ths.push(
                     <Th className={sortClass} key={index} onClick={this.handleClickTh.bind(this, column)}>
-                        {column.label}
+                        {column.label || column}
                     </Th>
                 );
             }
@@ -779,6 +779,12 @@
                 // Work around to get Thead > Tr > Th column names
                 if (this.props.children[0].props.children && this.props.children[0].props.children.props.children.length) {
                     columns = this.props.children[0].props.children.props.children.map(function(child) {
+                        if (child.props.children instanceof Unsafe) {
+                            return {
+                                key: child.props.column,
+                                label: child.props.children
+                            };
+                        }
                         return child.props.column;
                     });
                 }

--- a/src/reactable.jsx
+++ b/src/reactable.jsx
@@ -345,6 +345,7 @@
             for (var index = 0; index < this.props.columns.length; index++) {
                 var column = this.props.columns[index];
                 var sortClass = '';
+                var label = column.label || column;
 
                 if (this.props.sortableColumns[column.key]) {
                     sortClass += 'reactable-header-sortable ';
@@ -362,7 +363,7 @@
 
                 Ths.push(
                     <Th className={sortClass} key={index} onClick={this.handleClickTh.bind(this, column)}>
-                        {column.label || column}
+                        {label}
                     </Th>
                 );
             }
@@ -769,15 +770,18 @@
                         // Seems as if you can only access .contructor.displayName from
                         // within a CompositeComponent
                         // this.props.children[0].type.ConvenienceConstructor === Thead
-                        typeof this.props.children[0].props.displayName === 'string' && this.props.children[0].props.displayName.toLowerCase() === 'thead'
+                        typeof this.props.children[0].props.displayName === 'string' && 
+                        this.props.children[0].props.displayName.toLowerCase() === 'thead'
             ) {
                 // Remove thead row from data so it doesn't get inserted into the body
-                if (this.data[0].props && typeof this.data[0].props.displayName === 'string' && this.data[0].props.displayName.toLowerCase() === 'thead') {
+                if (this.data[0].props && typeof this.data[0].props.displayName === 'string' &&
+                    this.data[0].props.displayName.toLowerCase() === 'thead') {
                     this.data.splice(0, 1);
                 }
                 // columns = this.props.children[0].getColumns();
                 // Work around to get Thead > Tr > Th column names
-                if (this.props.children[0].props.children && this.props.children[0].props.children.props.children.length) {
+                if (this.props.children[0].props.children &&
+                    this.props.children[0].props.children.props.children.length) {
                     columns = this.props.children[0].props.children.props.children.map(function(child) {
                         if (child.props.children instanceof Unsafe) {
                             return {


### PR DESCRIPTION
I apologize for the hackyness in advance.

This allows you to defined a `Thead` within your tables, as well as having html `Th` elements within them. All you need to do is add the `displayName="thead"` on your `Thead`. It's pretty crazy you cant check the type of `ReactElement`, so until then, this is the solution I propose.

Something like:
```
<Table>
     <Thead displayName="thead">
         <Th column={key} key={'header' + i}>
             { unsafe('<span>Header</span>') }
         </Th>
     </Thead>
     // Rows...
</Table>
```
Things still mess up when inserting your own `Tbody` so I might add that soon along with tests. Aside from the tests, I think the components should be broken up into multiple files, which should make contributing a bit easier. It's kinda hard to see where things are at the moment. 

Anyway, expect more edits in the near future, as I'm using this for a project at Vimeo :smile:  