### PR TITLE
Allow filtering when cell data is null

### DIFF
--- a/src/reactable.jsx
+++ b/src/reactable.jsx
@@ -936,7 +936,7 @@
                 value.props.value : value.value;
         }
 
-        return value;
+        return (stringable(value) ? value : '');
     }
 
     var internalProps = {

--- a/tests/reactable_test.jsx
+++ b/tests/reactable_test.jsx
@@ -1272,6 +1272,42 @@ describe('Reactable', function() {
     });
 
     describe('filtering', function() {
+        describe('filtering with javascript objects for data', function(){
+            var data = [{name:"Lee SomeoneElse", age:18},{name:"Lee Salminen", age:23},{name:"No Age", age:null}]
+            before(function () {
+                React.render(
+                    <Reactable.Table className="table" id="table"
+                        filterable={['Name', 'Age']}>
+                        <Reactable.Tr>
+                            <Reactable.Td column="Name" data={data[0].name}/>
+                            <Reactable.Td column="Age" data={data[0].age}/>
+                        </Reactable.Tr>
+                        <Reactable.Tr>
+                            <Reactable.Td column="Name" data={data[1].name}/>
+                            <Reactable.Td column="Age" data={data[1].age}/>
+                        </Reactable.Tr>
+                        <Reactable.Tr>
+                            <Reactable.Td column="Name" data={data[2].name}/>
+                            <Reactable.Td column="Age" data={data[2].age}/>
+                        </Reactable.Tr>
+                    </Reactable.Table>,
+                    ReactableTestUtils.testNode()
+                );
+            });
+
+            after(ReactableTestUtils.resetTestEnvironment);
+
+            it('filters case insensitive on specified columns', function() {
+                var $filter = $('#table thead tr.reactable-filterer input.reactable-filter-input');
+
+                $filter.val('lee');
+                React.addons.TestUtils.Simulate.keyUp($filter[0]);
+
+                ReactableTestUtils.expectRowText(0, ['Lee SomeoneElse', '18']);
+                ReactableTestUtils.expectRowText(1, ['Lee Salminen', '23']);
+            });
+        });
+
         describe('basic case-insensitive filtering', function(){
             before(function() {
                 this.component = React.render(


### PR DESCRIPTION
We ran into an issue with json data containing null values populating table cells.  Everything rendered fine but when you filter the table, the call to 'extractDataFrom(....).toString() will blow up.  My fix includes checking whether the data value being used to filter is "stringable" (using the function in the code) and, if not, returning an empty string.  I've included a test case which should display the behavior on master and should be patched up on this branch.