### PR TITLE
Handle cases when <Tr>s or <Td>s are null

### DIFF
--- a/build/reactable.js
+++ b/build/reactable.js
@@ -510,39 +510,40 @@
                        return; // (continue)
                        }
                        */
-                    if (typeof(child.props) !== 'object') {
-                        return console.warn('Child passed to <Reactable.Table> was not an object: ' + child.toString());
-                    }
+                    if (child == null || typeof(child.props) !== 'object') { return; }
 
                     var childData = child.props.data || {};
 
                     React.Children.forEach(child.props.children, function(descendant) {
                         // TODO
                         /* if (descendant.type.ConvenienceConstructor === Td) { */
-                        if (true) {
-                            if (typeof(descendant.props.column) !== 'undefined') {
-                                var value;
+                        if (
+                            typeof(descendant) !== 'object' ||
+                            descendant == null
+                        ) {
+                            return;
+                        } else if (typeof(descendant.props.column) !== 'undefined') {
+                            var value;
 
-                                if (typeof(descendant.props.data) !== 'undefined') {
-                                    value = descendant.props.data;
-                                } else if (typeof(descendant.props.children) !== 'undefined') {
-                                    value = descendant.props.children;
-                                } else {
-                                    console.warn('exports.Td specified without ' +
-                                                 'a `data` property or children, ' +
-                                                 'ignoring');
-                                    return;
-                                }
-
-                                childData[descendant.props.column] = {
-                                    value: value,
-                                    props: filterPropsFrom(descendant.props),
-                                    __reactableMeta: true
-                                };
+                            if (typeof(descendant.props.data) !== 'undefined') {
+                                value = descendant.props.data;
+                            } else if (typeof(descendant.props.children) !== 'undefined') {
+                                value = descendant.props.children;
                             } else {
-                                console.warn('exports.Td specified without a ' +
-                                             '`column` property, ignoring');
+                                console.warn('exports.Td specified without ' +
+                                             'a `data` property or children, ' +
+                                             'ignoring');
+                                return;
                             }
+
+                            childData[descendant.props.column] = {
+                                value: value,
+                                props: filterPropsFrom(descendant.props),
+                                __reactableMeta: true
+                            };
+                        } else {
+                            console.warn('exports.Td specified without a ' +
+                                         '`column` property, ignoring');
                         }
                     });
 
@@ -936,7 +937,7 @@
                 value.props.value : value.value;
         }
 
-        return value;
+        return (stringable(value) ? value : '');
     }
 
     var internalProps = {

--- a/build/tests/reactable_test.js
+++ b/build/tests/reactable_test.js
@@ -267,7 +267,98 @@ describe('Reactable', function() {
             it('renders the third row with the correct data', function() {
                 ReactableTestUtils.expectRowText(2, ['', '28', 'Developer']);
             });
-        })
+        });
+
+        context('with null <Td>s', function(){
+            before(function() {
+                React.render(
+                    React.createElement(Reactable.Table, {className: "table", id: "table"}, 
+                        React.createElement(Reactable.Tr, null, 
+                            React.createElement(Reactable.Td, {column: "Name"}, React.createElement("b", null, "Griffin Smith")), 
+                            null
+                        ), 
+                        React.createElement(Reactable.Tr, null, 
+                            React.createElement(Reactable.Td, {column: "Name"}, React.createElement("b", null, "Lee Salminen")), 
+                            React.createElement(Reactable.Td, {column: "Age"}, React.createElement("em", null, "23"))
+                        ), 
+                        React.createElement(Reactable.Tr, null, 
+                            React.createElement(Reactable.Td, {column: "Position"}, React.createElement("b", null, "Developer")), 
+                            React.createElement(Reactable.Td, {column: "Age"}, React.createElement("em", null, "28"))
+                        )
+                    ),
+                    ReactableTestUtils.testNode()
+                );
+            });
+
+            after(ReactableTestUtils.resetTestEnvironment);
+
+            it('renders the table', function() {
+                expect($('table#table.table')).to.exist;
+            });
+
+            it('renders the column headers in the table', function() {
+                var headers = [];
+                $('thead th').each(function() {
+                    headers.push($(this).text());
+                });
+
+                expect(headers).to.eql([ 'Name', 'Age', 'Position' ]);
+            });
+
+            it('renders the first row with the correct data', function() {
+                ReactableTestUtils.expectRowText(0, ['Griffin Smith', '', '']);
+            });
+
+            it('renders the second row with the correct data', function() {
+                ReactableTestUtils.expectRowText(1, ['Lee Salminen', '23', '']);
+            });
+
+            it('renders the third row with the correct data', function() {
+                ReactableTestUtils.expectRowText(2, ['', '28', 'Developer']);
+            });
+        });
+
+        context('with null <Tr>s', function(){
+            before(function() {
+                React.render(
+                    React.createElement(Reactable.Table, {className: "table", id: "table"}, 
+                        React.createElement(Reactable.Tr, null, 
+                            React.createElement(Reactable.Td, {column: "Name"}, React.createElement("b", null, "Griffin Smith")), 
+                            React.createElement(Reactable.Td, {column: "Age"}, React.createElement("em", null, "18"))
+                        ), 
+                        null, 
+                        React.createElement(Reactable.Tr, null, 
+                            React.createElement(Reactable.Td, {column: "Position"}, React.createElement("b", null, "Developer")), 
+                            React.createElement(Reactable.Td, {column: "Age"}, React.createElement("em", null, "28"))
+                        )
+                    ),
+                    ReactableTestUtils.testNode()
+                );
+            });
+
+            after(ReactableTestUtils.resetTestEnvironment);
+
+            it('renders the table', function() {
+                expect($('table#table.table')).to.exist;
+            });
+
+            it('renders the column headers in the table', function() {
+                var headers = [];
+                $('thead th').each(function() {
+                    headers.push($(this).text());
+                });
+
+                expect(headers).to.eql([ 'Name', 'Age', 'Position' ]);
+            });
+
+            it('renders the first row with the correct data', function() {
+                ReactableTestUtils.expectRowText(0, ['Griffin Smith', '18', '']);
+            });
+
+            it('renders the second row with the correct data', function() {
+                ReactableTestUtils.expectRowText(1, ['', '28', 'Developer']);
+            });
+        });
     });
 
     describe('passing through HTML props', function() {
@@ -1272,6 +1363,42 @@ describe('Reactable', function() {
     });
 
     describe('filtering', function() {
+        describe('filtering with javascript objects for data', function(){
+            var data = [{name:"Lee SomeoneElse", age:18},{name:"Lee Salminen", age:23},{name:"No Age", age:null}]
+            before(function () {
+                React.render(
+                    React.createElement(Reactable.Table, {className: "table", id: "table", 
+                        filterable: ['Name', 'Age']}, 
+                        React.createElement(Reactable.Tr, null, 
+                            React.createElement(Reactable.Td, {column: "Name", data: data[0].name}), 
+                            React.createElement(Reactable.Td, {column: "Age", data: data[0].age})
+                        ), 
+                        React.createElement(Reactable.Tr, null, 
+                            React.createElement(Reactable.Td, {column: "Name", data: data[1].name}), 
+                            React.createElement(Reactable.Td, {column: "Age", data: data[1].age})
+                        ), 
+                        React.createElement(Reactable.Tr, null, 
+                            React.createElement(Reactable.Td, {column: "Name", data: data[2].name}), 
+                            React.createElement(Reactable.Td, {column: "Age", data: data[2].age})
+                        )
+                    ),
+                    ReactableTestUtils.testNode()
+                );
+            });
+
+            after(ReactableTestUtils.resetTestEnvironment);
+
+            it('filters case insensitive on specified columns', function() {
+                var $filter = $('#table thead tr.reactable-filterer input.reactable-filter-input');
+
+                $filter.val('lee');
+                React.addons.TestUtils.Simulate.keyUp($filter[0]);
+
+                ReactableTestUtils.expectRowText(0, ['Lee SomeoneElse', '18']);
+                ReactableTestUtils.expectRowText(1, ['Lee Salminen', '23']);
+            });
+        });
+
         describe('basic case-insensitive filtering', function(){
             before(function() {
                 this.component = React.render(

--- a/src/reactable.jsx
+++ b/src/reactable.jsx
@@ -510,39 +510,40 @@
                        return; // (continue)
                        }
                        */
-                    if (typeof(child.props) !== 'object') {
-                        return console.warn('Child passed to <Reactable.Table> was not an object: ' + child.toString());
-                    }
+                    if (child == null || typeof(child.props) !== 'object') { return; }
 
                     var childData = child.props.data || {};
 
                     React.Children.forEach(child.props.children, function(descendant) {
                         // TODO
                         /* if (descendant.type.ConvenienceConstructor === Td) { */
-                        if (true) {
-                            if (typeof(descendant.props.column) !== 'undefined') {
-                                var value;
+                        if (
+                            typeof(descendant) !== 'object' ||
+                            descendant == null
+                        ) {
+                            return;
+                        } else if (typeof(descendant.props.column) !== 'undefined') {
+                            var value;
 
-                                if (typeof(descendant.props.data) !== 'undefined') {
-                                    value = descendant.props.data;
-                                } else if (typeof(descendant.props.children) !== 'undefined') {
-                                    value = descendant.props.children;
-                                } else {
-                                    console.warn('exports.Td specified without ' +
-                                                 'a `data` property or children, ' +
-                                                 'ignoring');
-                                    return;
-                                }
-
-                                childData[descendant.props.column] = {
-                                    value: value,
-                                    props: filterPropsFrom(descendant.props),
-                                    __reactableMeta: true
-                                };
+                            if (typeof(descendant.props.data) !== 'undefined') {
+                                value = descendant.props.data;
+                            } else if (typeof(descendant.props.children) !== 'undefined') {
+                                value = descendant.props.children;
                             } else {
-                                console.warn('exports.Td specified without a ' +
-                                             '`column` property, ignoring');
+                                console.warn('exports.Td specified without ' +
+                                             'a `data` property or children, ' +
+                                             'ignoring');
+                                return;
                             }
+
+                            childData[descendant.props.column] = {
+                                value: value,
+                                props: filterPropsFrom(descendant.props),
+                                __reactableMeta: true
+                            };
+                        } else {
+                            console.warn('exports.Td specified without a ' +
+                                         '`column` property, ignoring');
                         }
                     });
 

--- a/tests/reactable_test.jsx
+++ b/tests/reactable_test.jsx
@@ -267,7 +267,98 @@ describe('Reactable', function() {
             it('renders the third row with the correct data', function() {
                 ReactableTestUtils.expectRowText(2, ['', '28', 'Developer']);
             });
-        })
+        });
+
+        context('with null <Td>s', function(){
+            before(function() {
+                React.render(
+                    <Reactable.Table className="table" id="table">
+                        <Reactable.Tr>
+                            <Reactable.Td column="Name"><b>Griffin Smith</b></Reactable.Td>
+                            {null}
+                        </Reactable.Tr>
+                        <Reactable.Tr>
+                            <Reactable.Td column="Name"><b>Lee Salminen</b></Reactable.Td>
+                            <Reactable.Td column="Age"><em>23</em></Reactable.Td>
+                        </Reactable.Tr>
+                        <Reactable.Tr>
+                            <Reactable.Td column="Position"><b>Developer</b></Reactable.Td>
+                            <Reactable.Td column="Age"><em>28</em></Reactable.Td>
+                        </Reactable.Tr>
+                    </Reactable.Table>,
+                    ReactableTestUtils.testNode()
+                );
+            });
+
+            after(ReactableTestUtils.resetTestEnvironment);
+
+            it('renders the table', function() {
+                expect($('table#table.table')).to.exist;
+            });
+
+            it('renders the column headers in the table', function() {
+                var headers = [];
+                $('thead th').each(function() {
+                    headers.push($(this).text());
+                });
+
+                expect(headers).to.eql([ 'Name', 'Age', 'Position' ]);
+            });
+
+            it('renders the first row with the correct data', function() {
+                ReactableTestUtils.expectRowText(0, ['Griffin Smith', '', '']);
+            });
+
+            it('renders the second row with the correct data', function() {
+                ReactableTestUtils.expectRowText(1, ['Lee Salminen', '23', '']);
+            });
+
+            it('renders the third row with the correct data', function() {
+                ReactableTestUtils.expectRowText(2, ['', '28', 'Developer']);
+            });
+        });
+
+        context('with null <Tr>s', function(){
+            before(function() {
+                React.render(
+                    <Reactable.Table className="table" id="table">
+                        <Reactable.Tr>
+                            <Reactable.Td column="Name"><b>Griffin Smith</b></Reactable.Td>
+                            <Reactable.Td column="Age"><em>18</em></Reactable.Td>
+                        </Reactable.Tr>
+                        {null}
+                        <Reactable.Tr>
+                            <Reactable.Td column="Position"><b>Developer</b></Reactable.Td>
+                            <Reactable.Td column="Age"><em>28</em></Reactable.Td>
+                        </Reactable.Tr>
+                    </Reactable.Table>,
+                    ReactableTestUtils.testNode()
+                );
+            });
+
+            after(ReactableTestUtils.resetTestEnvironment);
+
+            it('renders the table', function() {
+                expect($('table#table.table')).to.exist;
+            });
+
+            it('renders the column headers in the table', function() {
+                var headers = [];
+                $('thead th').each(function() {
+                    headers.push($(this).text());
+                });
+
+                expect(headers).to.eql([ 'Name', 'Age', 'Position' ]);
+            });
+
+            it('renders the first row with the correct data', function() {
+                ReactableTestUtils.expectRowText(0, ['Griffin Smith', '18', '']);
+            });
+
+            it('renders the second row with the correct data', function() {
+                ReactableTestUtils.expectRowText(1, ['', '28', 'Developer']);
+            });
+        });
     });
 
     describe('passing through HTML props', function() {


### PR DESCRIPTION
When looping through rows and columns, this simply returns if the row
or column is null. No warning is given, because this is a valid use
case where the row or column in question might need to be blank,
whereas before this commit you would have had to render an empty row or
column

Fixes #148