### PR TITLE
pagination enhancement

### DIFF
--- a/build/reactable.js
+++ b/build/reactable.js
@@ -217,16 +217,16 @@
 
     function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-    function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; }
+    function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
     var FiltererInput = (function (_React$Component) {
+        _inherits(FiltererInput, _React$Component);
+
         function FiltererInput() {
             _classCallCheck(this, FiltererInput);
 
             _get(Object.getPrototypeOf(FiltererInput.prototype), "constructor", this).apply(this, arguments);
         }
-
-        _inherits(FiltererInput, _React$Component);
 
         _createClass(FiltererInput, [{
             key: "onChange",
@@ -252,19 +252,19 @@
     ;
 
     var Filterer = (function (_React$Component2) {
+        _inherits(Filterer, _React$Component2);
+
         function Filterer() {
             _classCallCheck(this, Filterer);
 
             _get(Object.getPrototypeOf(Filterer.prototype), "constructor", this).apply(this, arguments);
         }
 
-        _inherits(Filterer, _React$Component2);
-
         _createClass(Filterer, [{
             key: "render",
             value: function render() {
-                if (typeof this.props.colSpan === "undefined") {
-                    throw new TypeError("Must pass a colSpan argument to Filterer");
+                if (typeof this.props.colSpan === 'undefined') {
+                    throw new TypeError('Must pass a colSpan argument to Filterer');
                 }
 
                 return React.createElement(
@@ -717,16 +717,16 @@
 
     function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-    function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; }
+    function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
     var Tfoot = (function (_React$Component) {
+        _inherits(Tfoot, _React$Component);
+
         function Tfoot() {
             _classCallCheck(this, Tfoot);
 
             _get(Object.getPrototypeOf(Tfoot.prototype), "constructor", this).apply(this, arguments);
         }
-
-        _inherits(Tfoot, _React$Component);
 
         _createClass(Tfoot, [{
             key: "render",
@@ -766,6 +766,52 @@
         }
 
         _createClass(Paginator, [{
+            key: 'handlePrevious',
+            value: function handlePrevious() {
+                this.props.onPageChange(this.props.currentPage - 1);
+            }
+        }, {
+            key: 'handleNext',
+            value: function handleNext() {
+                this.props.onPageChange(this.props.currentPage + 1);
+            }
+        }, {
+            key: 'handlePageButton',
+            value: function handlePageButton(page) {
+                this.props.onPageChange(page);
+            }
+        }, {
+            key: 'renderPrevious',
+            value: function renderPrevious() {
+                if (this.props.currentPage > 0) {
+                    return React.createElement(
+                        'a',
+                        { className: 'reactable-previous-page', onClick: this.handlePrevious.bind(this) },
+                        'Previous'
+                    );
+                }
+            }
+        }, {
+            key: 'renderNext',
+            value: function renderNext() {
+                if (this.props.currentPage < this.props.numPages - 1) {
+                    return React.createElement(
+                        'a',
+                        { className: 'reactable-next-page', onClick: this.handleNext.bind(this) },
+                        'Next'
+                    );
+                }
+            }
+        }, {
+            key: 'renderPageButton',
+            value: function renderPageButton(className, pageNum) {
+                return React.createElement(
+                    'a',
+                    { className: className, key: pageNum, onClick: this.handlePageButton.bind(this, pageNum) },
+                    pageNum + 1
+                );
+            }
+        }, {
             key: 'render',
             value: function render() {
                 if (typeof this.props.colSpan === 'undefined') {
@@ -781,24 +827,32 @@
                 }
 
                 var pageButtons = [];
-                for (var i = 0; i < this.props.numPages; i++) {
-                    var pageNum = i;
-                    var className = 'reactable-page-button';
-                    if (this.props.currentPage === i) {
-                        className += ' reactable-current-page';
-                    }
+                var pageButtonLimit = this.props.pageButtonLimit;
+                var currentPage = this.props.currentPage;
+                var numPages = this.props.numPages;
+                var lowerHalf = Math.round(pageButtonLimit / 2);
+                var upperHalf = pageButtonLimit - lowerHalf;
 
-                    pageButtons.push(React.createElement(
-                        'a',
-                        { className: className, key: i,
-                            // create function to get around for-loop closure issue
-                            onClick: (function (pageNum) {
-                                return (function () {
-                                    this.props.onPageChange(pageNum);
-                                }).bind(this);
-                            }).bind(this)(i) },
-                        i + 1
-                    ));
+                for (var i = 0; i < this.props.numPages; i++) {
+                    var showPageButton = false;
+                    var pageNum = i;
+                    var className = "reactable-page-button";
+                    if (currentPage === i) {
+                        className += " reactable-current-page";
+                    }
+                    pageButtons.push(this.renderPageButton(className, pageNum));
+                }
+
+                if (currentPage - pageButtonLimit + lowerHalf > 0) {
+                    if (currentPage > numPages - lowerHalf) {
+                        pageButtons.splice(0, numPages - pageButtonLimit);
+                    } else {
+                        pageButtons.splice(0, currentPage - pageButtonLimit + lowerHalf);
+                    }
+                }
+
+                if (numPages - currentPage > upperHalf) {
+                    pageButtons.splice(pageButtonLimit, pageButtons.length - pageButtonLimit);
                 }
 
                 return React.createElement(
@@ -810,7 +864,9 @@
                         React.createElement(
                             'td',
                             { colSpan: this.props.colSpan },
-                            pageButtons
+                            this.renderPrevious(),
+                            pageButtons,
+                            this.renderNext()
                         )
                     )
                 );
@@ -847,9 +903,11 @@
 
     function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
-    function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; }
+    function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
     var Table = (function (_React$Component) {
+        _inherits(Table, _React$Component);
+
         function Table(props) {
             _classCallCheck(this, Table);
 
@@ -871,18 +929,16 @@
             }
         }
 
-        _inherits(Table, _React$Component);
-
         _createClass(Table, [{
             key: 'filterBy',
             value: function filterBy(filter) {
                 this.setState({ filter: filter });
             }
-        }, {
-            key: 'translateColumnsArray',
 
             // Translate a user defined column array to hold column objects if strings are specified
             // (e.g. ['column1'] => [{key: 'column1', label: 'column1'}])
+        }, {
+            key: 'translateColumnsArray',
             value: function translateColumnsArray(columns) {
                 return columns.map((function (column, i) {
                     if (typeof column === 'string') {
@@ -1229,6 +1285,7 @@
                 var pagination = false;
                 var numPages = undefined;
                 var currentPage = this.state.currentPage;
+                var pageButtonLimit = this.props.pageButtonLimit || 10;
 
                 var currentChildren = filteredChildren;
                 if (this.props.itemsPerPage > 0) {
@@ -1266,6 +1323,7 @@
                         currentChildren
                     ),
                     pagination === true ? React.createElement(_paginator.Paginator, { colSpan: columns.length,
+                        pageButtonLimit: pageButtonLimit,
                         numPages: numPages,
                         currentPage: currentPage,
                         onPageChange: function (page) {

--- a/build/tests/reactable_test.js
+++ b/build/tests/reactable_test.js
@@ -910,6 +910,19 @@
         });
 
         describe('pagination', function () {
+            describe('specifying pageButtonLimit', function () {
+
+                before(function () {
+                    React.render(React.createElement(Reactable.Table, { className: 'table', id: 'table', data: [{ 'Name': 'Griffin Smith', 'Age': '18' }, { 'Age': '23', 'Name': 'Lee Salminen' }, { 'Age': '28', 'Position': 'Developer' }, { 'Name': 'Griffin Smith', 'Age': '18' }, { 'Age': '23', 'Name': 'Test Person' }, { 'Name': 'Ian Zhang', 'Age': '28', 'Position': 'Developer' }, { 'Name': 'Griffin Smith', 'Age': '18', 'Position': 'Software Developer' }, { 'Age': '23', 'Name': 'Lee Salminen' }, { 'Age': '28', 'Position': 'Developer' }, { 'Name': 'Griffin Smith', 'Age': '18' }, { 'Age': '23', 'Name': 'Lee Salminen' }, { 'Age': '28', 'Position': 'Developer' }, { 'Name': 'Griffin Smith', 'Age': '18' }, { 'Age': '23', 'Name': 'Test Person' }, { 'Name': 'Ian Zhang', 'Age': '28', 'Position': 'Developer' }, { 'Name': 'Griffin Smith', 'Age': '18', 'Position': 'Software Developer' }, { 'Age': '23', 'Name': 'Lee Salminen' }, { 'Age': '28', 'Position': 'Developer' }, { 'Name': 'Griffin Smith', 'Age': '18' }, { 'Age': '23', 'Name': 'Lee Salminen' }, { 'Age': '28', 'Position': 'Developer' }, { 'Name': 'Griffin Smith', 'Age': '18' }, { 'Age': '23', 'Name': 'Test Person' }, { 'Name': 'Ian Zhang', 'Age': '28', 'Position': 'Developer' }, { 'Name': 'Griffin Smith', 'Age': '18', 'Position': 'Software Developer' }, { 'Age': '23', 'Name': 'Lee Salminen' }, { 'Age': '28', 'Position': 'Developer' }], itemsPerPage: 2, pageButtonLimit: 8 }), ReactableTestUtils.testNode());
+                });
+
+                after(ReactableTestUtils.resetTestEnvironment);
+
+                it('shows no more page buttons than the pageButtonLimit', function () {
+                    var pageButtons = $('#table tbody.reactable-pagination a.reactable-page-button');
+                    expect(pageButtons.length).to.equal(8);
+                });
+            });
             describe('specifying itemsPerPage', function () {
                 before(function () {
                     React.render(React.createElement(Reactable.Table, { className: 'table', id: 'table', data: [{ 'Name': 'Griffin Smith', 'Age': '18' }, { 'Age': '23', 'Name': 'Lee Salminen' }, { 'Age': '28', 'Position': 'Developer' }, { 'Name': 'Griffin Smith', 'Age': '18' }, { 'Age': '23', 'Name': 'Test Person' }, { 'Name': 'Ian Zhang', 'Age': '28', 'Position': 'Developer' }, { 'Name': 'Griffin Smith', 'Age': '18', 'Position': 'Software Developer' }, { 'Age': '23', 'Name': 'Lee Salminen' }, { 'Age': '28', 'Position': 'Developer' }], itemsPerPage: 4 }), ReactableTestUtils.testNode());
@@ -933,6 +946,16 @@
                     var activePage = $('#table tbody.reactable-pagination a.reactable-page-button.reactable-current-page');
                     expect(activePage.length).to.equal(1);
                     expect(activePage).to.have.text('1');
+                });
+
+                it('does not show previous button', function () {
+                    var previousButton = $('#table tbody.reactable-pagination a.reactable-previous-page');
+                    expect(previousButton.length).to.equal(0);
+                });
+
+                it('shows next button', function () {
+                    var nextButton = $('#table tbody.reactable-pagination a.reactable-next-page');
+                    expect(nextButton.length).to.equal(1);
                 });
 
                 describe('clicking page buttons', function () {
@@ -965,6 +988,11 @@
                         expect($($(rows[2]).find('td')[0])).to.have.text('');
                         expect($($(rows[3]).find('td')[0])).to.have.text('Griffin Smith');
                     });
+
+                    it('shows previous button', function () {
+                        var previousButton = $('#table tbody.reactable-pagination a.reactable-previous-page');
+                        expect(previousButton.length).to.equal(1);
+                    });
                 });
             });
 
@@ -983,6 +1011,12 @@
                     var pageButtons = $('#table tbody.reactable-pagination a.reactable-page-button');
                     expect(pageButtons.length).to.equal(1);
                     expect($(pageButtons[0])).to.have.text('1');
+                });
+
+                it('does not show previous and next buttons', function () {
+                    var previousButton = $('#table tbody.reactable-pagination a.reactable-previous-page');
+                    var nextButton = $('#table tbody.reactable-pagination a.reactable-next-page');
+                    expect(previousButton.length + nextButton.length).to.equal(0);
                 });
             });
 
@@ -1582,7 +1616,7 @@
 
         describe('filtering', function () {
             describe('filtering with javascript objects for data', function () {
-                var data = [{ name: 'Lee SomeoneElse', age: 18 }, { name: 'Lee Salminen', age: 23 }, { name: 'No Age', age: null }];
+                var data = [{ name: "Lee SomeoneElse", age: 18 }, { name: "Lee Salminen", age: 23 }, { name: "No Age", age: null }];
                 before(function () {
                     React.render(React.createElement(
                         Reactable.Table,
@@ -1725,7 +1759,7 @@
 
                     it('filter placeholder is set', function () {
                         var $filter = $('#table thead tr.reactable-filterer input.reactable-filter-input');
-                        expect($filter.attr('placeholder')).to.equal('Filter Results');
+                        expect($filter.attr("placeholder")).to.equal('Filter Results');
                     });
                 });
 
@@ -1784,7 +1818,7 @@
                     $filter.val('colorado');
                     React.addons.TestUtils.Simulate.keyUp($filter[0]);
 
-                    ReactableTestUtils.expectRowText(0, ['Colorado', 'new description that shouldn\'t match filter', 'old']);
+                    ReactableTestUtils.expectRowText(0, ['Colorado', "new description that shouldn't match filter", 'old']);
                     var activePage = $('#table tbody.reactable-pagination ' + 'a.reactable-page-button.reactable-current-page');
                     expect(activePage.length).to.equal(1);
                     expect(activePage).to.have.text('1');

--- a/src/reactable/paginator.jsx
+++ b/src/reactable/paginator.jsx
@@ -1,4 +1,33 @@
 export class Paginator {
+
+    handlePrevious() {
+        this.props.onPageChange(this.props.currentPage - 1)
+    }
+
+    handleNext() {
+        this.props.onPageChange(this.props.currentPage + 1);
+    }
+
+    handlePageButton(page) {
+        this.props.onPageChange(page);
+    }
+
+    renderPrevious() {
+        if(this.props.currentPage > 0) {
+            return <a className='reactable-previous-page' onClick={this.handlePrevious.bind(this)}>Previous</a>
+        }
+    }
+
+    renderNext() {
+        if(this.props.currentPage < this.props.numPages - 1) {
+            return <a className='reactable-next-page' onClick={this.handleNext.bind(this)}>Next</a>
+        }
+    }
+
+    renderPageButton(className, pageNum) {
+        return <a className={className} key={pageNum} onClick={this.handlePageButton.bind(this, pageNum)}>{pageNum + 1}</a>
+    }
+
     render() {
         if (typeof this.props.colSpan === 'undefined') {
             throw new TypeError('Must pass a colSpan argument to Paginator');
@@ -12,30 +41,42 @@ export class Paginator {
             throw new TypeError('Must pass a currentPage argument to Paginator');
         }
 
-        var pageButtons = [];
-        for (var i = 0; i < this.props.numPages; i++) {
-            var pageNum = i;
-            var className = "reactable-page-button";
-            if (this.props.currentPage === i) {
+        let pageButtons = [];
+        let pageButtonLimit = this.props.pageButtonLimit;
+        let currentPage = this.props.currentPage;
+        let numPages = this.props.numPages;
+        let lowerHalf = Math.round( pageButtonLimit / 2 );
+        let upperHalf = (pageButtonLimit - lowerHalf);
+
+        for (let i = 0; i < this.props.numPages; i++) {
+            let showPageButton = false;
+            let pageNum = i;
+            let className = "reactable-page-button";
+            if (currentPage === i) {
                 className += " reactable-current-page";
             }
+            pageButtons.push( this.renderPageButton(className, pageNum));
+        }
 
-            pageButtons.push(
-                <a className={className} key={i}
-                    // create function to get around for-loop closure issue
-                    onClick={(function(pageNum) {
-                        return function() {
-                            this.props.onPageChange(pageNum);
-                        }.bind(this);
-                    }.bind(this))(i)}>{i + 1}</a>
-            );
+        if(currentPage - pageButtonLimit + lowerHalf > 0) {
+            if(currentPage > numPages - lowerHalf) {
+                pageButtons.splice(0, numPages - pageButtonLimit)
+            } else {
+                pageButtons.splice(0, currentPage - pageButtonLimit + lowerHalf);
+            }
+        }
+
+        if((numPages - currentPage) > upperHalf) {
+            pageButtons.splice(pageButtonLimit, pageButtons.length - pageButtonLimit);
         }
 
         return (
             <tbody className="reactable-pagination">
                 <tr>
                     <td colSpan={this.props.colSpan}>
+                        {this.renderPrevious()}
                         {pageButtons}
+                        {this.renderNext()}
                     </td>
                 </tr>
             </tbody>

--- a/src/reactable/table.jsx
+++ b/src/reactable/table.jsx
@@ -384,6 +384,7 @@ export class Table extends React.Component {
         let pagination = false;
         let numPages;
         let currentPage = this.state.currentPage;
+        let pageButtonLimit = this.props.pageButtonLimit || 10;
 
         let currentChildren = filteredChildren;
         if (this.props.itemsPerPage > 0) {
@@ -423,6 +424,7 @@ export class Table extends React.Component {
             </tbody>
             {pagination === true ?
              <Paginator colSpan={columns.length}
+                 pageButtonLimit={pageButtonLimit}
                  numPages={numPages}
                  currentPage={currentPage}
                  onPageChange={page => {

--- a/tests/reactable_test.jsx
+++ b/tests/reactable_test.jsx
@@ -700,6 +700,51 @@ describe('Reactable', function() {
     });
 
     describe('pagination', function() {
+        describe('specifying pageButtonLimit', function(){
+
+            before(function() {
+                React.render(
+                    <Reactable.Table className="table" id="table" data={[
+                        {'Name': 'Griffin Smith', 'Age': '18'},
+                        {'Age': '23', 'Name': 'Lee Salminen'},
+                        {'Age': '28', 'Position': 'Developer'},
+                        {'Name': 'Griffin Smith', 'Age': '18'},
+                        {'Age': '23', 'Name': 'Test Person'},
+                        {'Name': 'Ian Zhang', 'Age': '28', 'Position': 'Developer'},
+                        {'Name': 'Griffin Smith', 'Age': '18', 'Position': 'Software Developer'},
+                        {'Age': '23', 'Name': 'Lee Salminen'},
+                        {'Age': '28', 'Position': 'Developer'},
+                        {'Name': 'Griffin Smith', 'Age': '18'},
+                        {'Age': '23', 'Name': 'Lee Salminen'},
+                        {'Age': '28', 'Position': 'Developer'},
+                        {'Name': 'Griffin Smith', 'Age': '18'},
+                        {'Age': '23', 'Name': 'Test Person'},
+                        {'Name': 'Ian Zhang', 'Age': '28', 'Position': 'Developer'},
+                        {'Name': 'Griffin Smith', 'Age': '18', 'Position': 'Software Developer'},
+                        {'Age': '23', 'Name': 'Lee Salminen'},
+                        {'Age': '28', 'Position': 'Developer'},
+                        {'Name': 'Griffin Smith', 'Age': '18'},
+                        {'Age': '23', 'Name': 'Lee Salminen'},
+                        {'Age': '28', 'Position': 'Developer'},
+                        {'Name': 'Griffin Smith', 'Age': '18'},
+                        {'Age': '23', 'Name': 'Test Person'},
+                        {'Name': 'Ian Zhang', 'Age': '28', 'Position': 'Developer'},
+                        {'Name': 'Griffin Smith', 'Age': '18', 'Position': 'Software Developer'},
+                        {'Age': '23', 'Name': 'Lee Salminen'},
+                        {'Age': '28', 'Position': 'Developer'},
+                    ]} itemsPerPage={2} pageButtonLimit={8}/>,
+                    ReactableTestUtils.testNode()
+                );
+            });
+
+            after(ReactableTestUtils.resetTestEnvironment);
+
+            it('shows no more page buttons than the pageButtonLimit', function() {
+                var pageButtons = $('#table tbody.reactable-pagination a.reactable-page-button');
+                expect(pageButtons.length).to.equal(8);
+            });
+
+        })
         describe('specifying itemsPerPage', function(){
             before(function() {
                 React.render(
@@ -738,6 +783,16 @@ describe('Reactable', function() {
                 expect(activePage).to.have.text('1');
             });
 
+            it('does not show previous button', function(){
+                var previousButton = $('#table tbody.reactable-pagination a.reactable-previous-page');
+                expect(previousButton.length).to.equal(0);
+            });
+
+            it('shows next button', function(){
+                var nextButton = $('#table tbody.reactable-pagination a.reactable-next-page');
+                expect(nextButton.length).to.equal(1);
+            });
+
             describe('clicking page buttons', function() {
                 beforeEach(function() {
                     var page2 = $('#table tbody.reactable-pagination a.reactable-page-button')[1];
@@ -767,6 +822,11 @@ describe('Reactable', function() {
                     expect($($(rows[1]).find('td')[0])).to.have.text('Lee Salminen');
                     expect($($(rows[2]).find('td')[0])).to.have.text('');
                     expect($($(rows[3]).find('td')[0])).to.have.text('Griffin Smith');
+                });
+
+                it('shows previous button', function(){
+                    var previousButton = $('#table tbody.reactable-pagination a.reactable-previous-page');
+                    expect(previousButton.length).to.equal(1);
                 });
             });
         });
@@ -800,6 +860,13 @@ describe('Reactable', function() {
                 expect(pageButtons.length).to.equal(1);
                 expect($(pageButtons[0])).to.have.text('1')
             });
+
+            it('does not show previous and next buttons', function(){
+                var previousButton = $('#table tbody.reactable-pagination a.reactable-previous-page');
+                var nextButton = $('#table tbody.reactable-pagination a.reactable-next-page');
+                expect(previousButton.length + nextButton.length).to.equal(0);
+            })
+
         });
 
         describe('not specifying itemsPerPage', function(){


### PR DESCRIPTION
- adds a previous and next button.  Previous button does not appear on first page.  Next button does not appear on last page.
- sets a limit to how many pages are shown in the paginator, with a `pageButtonLimit` prop.  Defaults to 10 if that prop isn't set.
- current page number appear as close to the middle of the set as possible, depending on how many pages are to the left and to the right.  See Google's pattern for an example.
- adds test