### PR TITLE
Support beta versions of React as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "./node_modules/grunt-cli/bin/grunt testOnce"
   },
   "peerDependencies": {
-    "react": "*"
+    "react": "* || ^0.14.0-beta1"
   },
   "devDependencies": {
     "grunt": "^0.4.4",


### PR DESCRIPTION
In semver, `*` doesn't match any prerelease version, so you can't use `reactable` with beta versions of React. 

```
npm ERR! peerinvalid The package react does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer formsy-react@0.15.1 wants react@^0.14.0-beta3
npm ERR! peerinvalid Peer reactable@0.10.2 wants react@*
```

Adding an explicit prerelease version allows `reactable` to install along side any or non beta version.