### PR TITLE
Allow for customizing rendering of Reactable.Th

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ as of version 0.10.0 Reactable will only continue to support React
   - [Further Customization](#further-customization)
   - [Even More Customization](#even-more-customization)
   - [Additional node types](#additional-node-types)
-  - [Manually specifying columns](#manually-specifying-columns)
+  - [Customizing Columns](#manually-specifying-columns)
   - [Preventing escaping of HTML](#preventing-escaping-of-html)
   - [Pagination](#pagination)
   - [Sorting](#sorting)
@@ -142,24 +142,68 @@ React.renderComponent(
 );
 ```
 
+### Customizing Columns
+
+To override inferring the column list from the attributes of the passed `data`
+objects, you can either:
+
+- Pass a `columns` array property to the `<Table>` component, which can be
+  either:
+  - An array of strings, in which case only the given properties will be included
+    as columns in the rendered table.
+  - An array of objects, each of which must have a `key` and `label` property.
+    The `key` property is the attribute of the row object from which to retrieve
+    value, and the `label` is the text to render in the column header row.
+- Define a `<Thead>` component as the **first child** of the `<Table>`, with
+  `<Th>` components as children (note the exclusion of a `<Tr>` here),
+  each of which should have a "column" property. The children of these `<Th>`
+  components (either strings or React components themselves) will be used to
+  render the table headers. For example:
+
+```jsx
+var Table = Reactable.Table,
+    Thead = Reactable.Thead,
+    Th = Reactable.Th,
+    Tr = Reactable.Tr,
+    Td = Reactable.Td;
+
+React.renderComponent(
+    <Table className="table" id="table">
+        <Thead>
+          <Th column="name">
+            <strong class="name-header">First Name, Last Name</strong>
+          </Th>
+          <Th column="age">
+            <em class="age-header">Age, years</em>
+          </Th>
+        </Thead>
+        <Tr>
+            <Td column="name" data="Griffin Smith">
+                <b>Griffin Smith</b>
+            </Td>
+            <Td column="age">18</Td>
+        </Tr>
+        <Tr>
+            <Td column="name">Lee Salminen</Td>
+            <Td column="age">23</Td>
+        </Tr>
+        <Tr>
+            <Td column="position">Developer</Td>
+            <Td column="age">28</Td>
+        </Tr>
+    </Table>,
+    document.getElementById('table')
+);
+```
+
+In this example, the `position` column will **not** be rendered.
+
 ### Additional node types
 
 Reactable also supports specifying a `<tfoot>` for your table, via the
 `Reactable.Tfoot` class. Per the HTML spec, there can only be one `<Tfoot>` per
 table and its only children should be React.DOM `<tr>` elements (**not**
 `<Reactable.Tr>` elements).
-
-### Manually specifying columns
-
-To override the automatic grabbing of the column list from the attributes of the
-passed `data` objects, you can pass a `columns` property to the `<Table>`
-component. This can be either:
-
-- An array of strings, in which case only the given properties will be included
-  as columns in the rendered table.
-- An array of objects, each of which must have a `key` and `label` property. The
-  `key` property is the attribute of the row object from which to retrieve
-  value, and the `label` is the text to render in the column header row.
 
 ### Preventing escaping of HTML
 

--- a/build/reactable.js
+++ b/build/reactable.js
@@ -651,17 +651,6 @@ window.React["default"] = window.React;
         }
 
         _createClass(Thead, [{
-            key: 'getColumns',
-            value: function getColumns() {
-                return _react['default'].Children.map(this.props.children, function (th) {
-                    if (typeof th.props.children === 'string') {
-                        return th.props.children;
-                    } else {
-                        throw new TypeError('<th> must have a string child');
-                    }
-                });
-            }
-        }, {
             key: 'handleClickTh',
             value: function handleClickTh(column) {
                 this.props.onSort(column.key);
@@ -719,6 +708,26 @@ window.React["default"] = window.React;
                         Ths
                     )
                 );
+            }
+        }], [{
+            key: 'getColumns',
+            value: function getColumns(component) {
+                // Can't use React.Children.map since that doesn't return a proper array
+                var columns = [];
+                _react['default'].Children.forEach(component.props.children, function (th) {
+                    if (typeof th.props.children === 'string') {
+                        columns.push(th.props.children);
+                    } else if (typeof th.props.column === 'string') {
+                        columns.push({
+                            key: th.props.column,
+                            label: th.props.children
+                        });
+                    } else {
+                        throw new TypeError('<th> must have either a "column" property or a string ' + 'child');
+                    }
+                });
+
+                return columns;
             }
         }]);
 
@@ -1254,8 +1263,16 @@ window.React["default"] = window.React;
                 var columns = undefined;
                 var userColumnsSpecified = false;
 
+                var firstChild = null;
+
                 if (this.props.children && this.props.children.length > 0 && this.props.children[0].type === _thead.Thead) {
-                    columns = this.props.children[0].getColumns();
+                    fistChild = this.props.children[0];
+                } else if (typeof this.props.children !== 'undefined' && this.props.children.type === _thead.Thead) {
+                    firstChild = this.props.children;
+                }
+
+                if (firstChild !== null) {
+                    columns = _thead.Thead.getColumns(firstChild);
                 } else {
                     columns = this.props.columns || [];
                 }

--- a/build/tests/reactable_test.js
+++ b/build/tests/reactable_test.js
@@ -764,6 +764,39 @@
             });
         });
 
+        describe('specifying columns using a <Thead>', function () {
+            before(function () {
+                React.render(React.createElement(
+                    Reactable.Table,
+                    { id: 'table', data: [{ Name: Reactable.unsafe('<span id="griffins-name">Griffin Smith</span>'), Age: '18' }, { Age: '28', Position: Reactable.unsafe('<span id="who-knows-job">Developer</span>') }, { Age: '23', Name: Reactable.unsafe('<span id="lees-name">Lee Salminen</span>') }] },
+                    React.createElement(
+                        Reactable.Thead,
+                        null,
+                        React.createElement(
+                            Reactable.Th,
+                            { column: 'Name', id: 'my-name' },
+                            React.createElement(
+                                'strong',
+                                null,
+                                'name'
+                            )
+                        )
+                    )
+                ), ReactableTestUtils.testNode());
+            });
+
+            after(ReactableTestUtils.resetTestEnvironment);
+
+            it('renders only the columns in the Thead', function () {
+                expect($('#table tbody tr:first td')).to.exist;
+                expect($('#table thead tr:first th')).to.exist;
+            });
+
+            it('renders the contents of the Th', function () {
+                expect($('#table>thead>tr>th>strong')).to.exist;
+            });
+        });
+
         describe('unsafe() strings', function () {
             context('in the <Table> directly', function () {
                 before(function () {

--- a/lib/reactable/table.js
+++ b/lib/reactable/table.js
@@ -344,8 +344,16 @@ var Table = (function (_React$Component) {
             var columns = undefined;
             var userColumnsSpecified = false;
 
+            var firstChild = null;
+
             if (this.props.children && this.props.children.length > 0 && this.props.children[0].type === _thead.Thead) {
-                columns = this.props.children[0].getColumns();
+                fistChild = this.props.children[0];
+            } else if (typeof this.props.children !== 'undefined' && this.props.children.type === _thead.Thead) {
+                firstChild = this.props.children;
+            }
+
+            if (firstChild !== null) {
+                columns = _thead.Thead.getColumns(firstChild);
             } else {
                 columns = this.props.columns || [];
             }

--- a/lib/reactable/thead.js
+++ b/lib/reactable/thead.js
@@ -34,17 +34,6 @@ var Thead = (function (_React$Component) {
     }
 
     _createClass(Thead, [{
-        key: 'getColumns',
-        value: function getColumns() {
-            return _react2['default'].Children.map(this.props.children, function (th) {
-                if (typeof th.props.children === 'string') {
-                    return th.props.children;
-                } else {
-                    throw new TypeError('<th> must have a string child');
-                }
-            });
-        }
-    }, {
         key: 'handleClickTh',
         value: function handleClickTh(column) {
             this.props.onSort(column.key);
@@ -102,6 +91,26 @@ var Thead = (function (_React$Component) {
                     Ths
                 )
             );
+        }
+    }], [{
+        key: 'getColumns',
+        value: function getColumns(component) {
+            // Can't use React.Children.map since that doesn't return a proper array
+            var columns = [];
+            _react2['default'].Children.forEach(component.props.children, function (th) {
+                if (typeof th.props.children === 'string') {
+                    columns.push(th.props.children);
+                } else if (typeof th.props.column === 'string') {
+                    columns.push({
+                        key: th.props.column,
+                        label: th.props.children
+                    });
+                } else {
+                    throw new TypeError('<th> must have either a "column" property or a string ' + 'child');
+                }
+            });
+
+            return columns;
         }
     }]);
 

--- a/src/reactable/table.jsx
+++ b/src/reactable/table.jsx
@@ -303,12 +303,23 @@ export class Table extends React.Component {
         let columns;
         let userColumnsSpecified = false;
 
+        let firstChild = null;
+
         if (
             this.props.children &&
             this.props.children.length > 0 &&
             this.props.children[0].type === Thead
         ) {
-            columns = this.props.children[0].getColumns();
+            fistChild = this.props.children[0]
+        } else if (
+            typeof this.props.children !== 'undefined' &&
+            this.props.children.type === Thead
+        ) {
+            firstChild = this.props.children
+        }
+
+        if (firstChild !== null) {
+            columns = Thead.getColumns(firstChild);
         } else {
             columns = this.props.columns || [];
         }

--- a/src/reactable/thead.jsx
+++ b/src/reactable/thead.jsx
@@ -4,14 +4,25 @@ import { Filterer } from './filterer';
 import { filterPropsFrom } from './lib/filter_props_from';
 
 export class Thead extends React.Component {
-    getColumns() {
-        return React.Children.map(this.props.children, function(th) {
+    static getColumns(component) {
+        // Can't use React.Children.map since that doesn't return a proper array
+        let columns = [];
+        React.Children.forEach(component.props.children, th => {
             if (typeof th.props.children === 'string') {
-                return th.props.children;
+                columns.push(th.props.children);
+            } else if (typeof th.props.column === 'string') {
+                columns.push({
+                    key: th.props.column,
+                    label: th.props.children
+                });
             } else {
-                throw new TypeError('<th> must have a string child');
+                throw new TypeError(
+                    '<th> must have either a "column" property or a string ' +
+                        'child');
             }
         });
+
+        return columns;
     }
 
     handleClickTh(column) {

--- a/tests/reactable_test.jsx
+++ b/tests/reactable_test.jsx
@@ -560,6 +560,36 @@ describe('Reactable', function() {
         });
     });
 
+    describe('specifying columns using a <Thead>', function() {
+        before(function() {
+            React.render(
+                <Reactable.Table id="table" data={[
+                    { Name: Reactable.unsafe('<span id="griffins-name">Griffin Smith</span>'), Age: '18'},
+                    { Age: '28', Position: Reactable.unsafe('<span id="who-knows-job">Developer</span>')},
+                    { Age: '23', Name: Reactable.unsafe('<span id="lees-name">Lee Salminen</span>')},
+                ]}>
+                    <Reactable.Thead>
+                        <Reactable.Th column="Name" id="my-name">
+                            <strong>name</strong>
+                        </Reactable.Th>
+                    </Reactable.Thead>
+                </Reactable.Table>,
+                ReactableTestUtils.testNode()
+            );
+        });
+
+        after(ReactableTestUtils.resetTestEnvironment);
+
+        it('renders only the columns in the Thead', function() {
+            expect($('#table tbody tr:first td')).to.exist;
+            expect($('#table thead tr:first th')).to.exist;
+        });
+
+        it('renders the contents of the Th', function() {
+            expect($('#table>thead>tr>th>strong')).to.exist;
+        });
+    });
+
     describe('unsafe() strings', function() {
         context('in the <Table> directly', function() {
             before(function() {


### PR DESCRIPTION
Allow for specifying a `Reactable.Thead` with one or many
`Reactable.Th`s in it, each of which must have a `column` prop.

Fixes #182