### PR TITLE
add improved pagination

### DIFF
--- a/src/reactable/paginator.jsx
+++ b/src/reactable/paginator.jsx
@@ -5,6 +5,11 @@ function pageHref(num) {
 }
 
 export class Paginator extends React.Component {
+    handleFirst(e) {
+        e.preventDefault()
+        this.props.onPageChange(1);
+    }
+
     handlePrevious(e) {
         e.preventDefault()
         this.props.onPageChange(this.props.currentPage - 1)
@@ -13,6 +18,11 @@ export class Paginator extends React.Component {
     handleNext(e) {
         e.preventDefault()
         this.props.onPageChange(this.props.currentPage + 1);
+    }
+
+    handleLast(e) {
+        e.preventDefault()
+        this.props.onPageChange(this.props.numPages - 1);
     }
 
     handlePageButton(page, e) {
@@ -50,6 +60,11 @@ export class Paginator extends React.Component {
               </a>
     }
 
+    renderEllipsis(className) {
+
+        return <span className={className}> ... </span>
+    }
+
     render() {
         if (typeof this.props.colSpan === 'undefined') {
             throw new TypeError('Must pass a colSpan argument to Paginator');
@@ -67,38 +82,57 @@ export class Paginator extends React.Component {
         let pageButtonLimit = this.props.pageButtonLimit;
         let currentPage = this.props.currentPage;
         let numPages = this.props.numPages;
-        let lowerHalf = Math.round( pageButtonLimit / 2 );
-        let upperHalf = (pageButtonLimit - lowerHalf);
+        let lastPage = numPages - 1;
+        // total number of visible buttons
+        // 2 * limit + 2 * Ellipsis + 1 currentPage + 2 First/Last
+        let buttonsNumber = 2 * pageButtonLimit + 2 + 1 + 2;
 
         for (let i = 0; i < this.props.numPages; i++) {
             let showPageButton = false;
-            let pageNum = i;
             let className = "reactable-page-button";
             if (currentPage === i) {
                 className += " reactable-current-page";
             }
-            pageButtons.push( this.renderPageButton(className, pageNum));
-        }
 
-        if(currentPage - pageButtonLimit + lowerHalf > 0) {
-            if(currentPage > numPages - lowerHalf) {
-                pageButtons.splice(0, numPages - pageButtonLimit)
-            } else {
-                pageButtons.splice(0, currentPage - pageButtonLimit + lowerHalf);
+            // always render first and last page button
+            if ( i == 0 || i == lastPage ) {
+                pageButtons.push( this.renderPageButton(className, i));
+                continue;
             }
-        }
 
-        if((numPages - currentPage) > upperHalf) {
-            pageButtons.splice(pageButtonLimit, pageButtons.length - pageButtonLimit);
+            // always render number of buttons around active
+            if ( i >= (currentPage - pageButtonLimit) && i <= (currentPage + pageButtonLimit) ) {
+                pageButtons.push( this.renderPageButton(className, i));
+                continue;
+            }
+
+            // complicated stuff :)
+            // just keeps equal number of visible buttons for every possible case
+            // 4 = first + last + 1 ellipsis + currentPage
+            // 2 = first/last + ellipsis
+            if (this.props.keepButtonsNumber) {
+                if ( currentPage < buttonsNumber - 4 && i < buttonsNumber - 2
+                  || currentPage > lastPage - (buttonsNumber - 4) && i > (lastPage - (buttonsNumber - 2)) ) {
+                    pageButtons.push( this.renderPageButton(className, i));
+                    continue;
+                }
+            }
+
+            // at this point render ellipsis instead of second button 
+            // and button second from the end
+            if ( i == 1 || i == (lastPage - 1) ) {
+                pageButtons.push( this.renderEllipsis(className) );
+                continue;
+            }
         }
 
         return (
             <tbody className="reactable-pagination">
                 <tr>
                     <td colSpan={this.props.colSpan}>
-                        {this.renderPrevious()}
-                        {pageButtons}
-                        {this.renderNext()}
+                      {this.renderPrevious()}
+                      {pageButtons}
+                      {this.renderNext()}
                     </td>
                 </tr>
             </tbody>

--- a/src/reactable/table.jsx
+++ b/src/reactable/table.jsx
@@ -397,6 +397,7 @@ export class Table extends React.Component {
         let numPages;
         let currentPage = this.state.currentPage;
         let pageButtonLimit = this.props.pageButtonLimit || 10;
+        let keepButtonsNumber = this.props.keepButtonsNumber || false;
 
         let currentChildren = filteredChildren;
         if (this.props.itemsPerPage > 0) {
@@ -437,6 +438,7 @@ export class Table extends React.Component {
             {pagination === true ?
              <Paginator colSpan={columns.length}
                  pageButtonLimit={pageButtonLimit}
+                 keepButtonsNumber={keepButtonsNumber}
                  numPages={numPages}
                  currentPage={currentPage}
                  onPageChange={page => {


### PR DESCRIPTION
Improves pagination by:
- keeping always the same number of visible buttons (as an option `keepButtonsNumber` true/false, defaults to false)
- always show first/last buttons (if not on first/last page)
- adds ellipsis "symbol" for invisible part of pagination
- changes behavior of `pageButtonLimit` option it is now **not** the total number of buttons but **number of buttons on each side from active** button (previous meaning of this option doesn't make sense for my solution)

Examples has settings `keepButtonsNumber=true` and `pageButtonLimit={1}`.
This is how it looks like with default styling:
![image](https://cloud.githubusercontent.com/assets/4281333/10209537/d54526d4-67dc-11e5-939d-f3fdec8a5f00.png)

And here is pagination styled with bootstrap 3 (I didn't make pull request with bootstrap version but if you want it I can share it):
![image](https://cloud.githubusercontent.com/assets/4281333/10209555/f1996818-67dc-11e5-89db-24b8bcb5207c.png)