### PR TITLE
Implement configurable text for table with no data

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,3 +425,19 @@ var table = React.render(
 
 These can be useful if you want to roll your own filtering input field
 outside of Reactable.
+
+### Empty Data Sets
+
+If the table is initialized without any `<Tr>`s or with an empty array for
+`data`, you can display text in the body of the table by passing a string
+for the optional `noDataText` prop:
+
+```jsx
+var table = React.render(
+  <Table
+    className="table"
+    id="table" data={[]}
+    noDataText="No matching records found." />,
+  document.getElementById('table')
+);
+```

--- a/src/reactable/table.jsx
+++ b/src/reactable/table.jsx
@@ -420,6 +420,8 @@ export class Table extends React.Component {
         // Manually transfer props
         let props = filterPropsFrom(this.props);
 
+        let noDataText = this.props.noDataText ? <span className="reactable-no-data">{this.props.noDataText}</span> : null;
+
         return <table {...props}>
             {columns && columns.length > 0 ?
              <Thead columns={columns}
@@ -435,7 +437,7 @@ export class Table extends React.Component {
                  key="thead"/>
              : null}
             <tbody className="reactable-data" key="tbody">
-                {currentChildren}
+                {currentChildren.length > 0 ? currentChildren : noDataText}
             </tbody>
             {pagination === true ?
              <Paginator colSpan={columns.length}

--- a/tests/reactable_test.jsx
+++ b/tests/reactable_test.jsx
@@ -1917,4 +1917,97 @@ describe('Reactable', function() {
             expect(this.clicked).to.eq(true);
         });
     });
+
+    describe('table with no data', () => {
+      context('when noDataText prop is null', () => {
+        before(function() {
+          this.component = ReactDOM.render(
+            <Reactable.Table data={[]} columns={['State', 'Description', 'Tag']}></Reactable.Table>,
+              ReactableTestUtils.testNode()
+            );
+          });
+
+          after(ReactableTestUtils.resetTestEnvironment);
+
+          it('does not render the reactable-no-data element', () => {
+            expect($('.reactable-no-data').length).to.eq(0);
+          });
+        });
+
+      context('when initialized without <Tr>s', () => {
+        before(function() {
+            this.component = ReactDOM.render(
+                <Reactable.Table className="table" id="table" columns={['State', 'Description', 'Tag']} noDataText="No matching records found."></Reactable.Table>,
+                ReactableTestUtils.testNode()
+            );
+        });
+
+        after(ReactableTestUtils.resetTestEnvironment);
+
+        it('shows the "no data" message', () => {
+          var $text = $('.reactable-no-data').text();
+          expect($text).to.eq('No matching records found.');
+        });
+      });
+
+      context('when filtered without any matches', () => {
+        before(function() {
+            this.component = ReactDOM.render(
+                <Reactable.Table className="table" id="table"
+                    filterable={['State', 'Tag']}
+                    filterPlaceholder="Filter Results"
+                    filterBy='xxxxx'
+                    noDataText="No matching records found."
+                    columns={['State', 'Description', 'Tag']}>
+                    <Reactable.Tr>
+                        <Reactable.Td column='State'>New York</Reactable.Td>
+                        <Reactable.Td column='Description'>this is some text</Reactable.Td>
+                        <Reactable.Td column='Tag'>new</Reactable.Td>
+                    </Reactable.Tr>
+                    <Reactable.Tr>
+                        <Reactable.Td column='State'>New Mexico</Reactable.Td>
+                        <Reactable.Td column='Description'>lorem ipsum</Reactable.Td>
+                        <Reactable.Td column='Tag'>old</Reactable.Td>
+                    </Reactable.Tr>
+                    <Reactable.Tr>
+                        <Reactable.Td column='State'>Colorado</Reactable.Td>
+                        <Reactable.Td column='Description'>
+                            new description that shouldnt match filter
+                        </Reactable.Td>
+                        <Reactable.Td column='Tag'>old</Reactable.Td>
+                    </Reactable.Tr>
+                    <Reactable.Tr>
+                        <Reactable.Td column='State'>Alaska</Reactable.Td>
+                        <Reactable.Td column='Description'>bacon</Reactable.Td>
+                        <Reactable.Td column='Tag'>renewed</Reactable.Td>
+                    </Reactable.Tr>
+                </Reactable.Table>,
+                ReactableTestUtils.testNode()
+            );
+        });
+
+        after(ReactableTestUtils.resetTestEnvironment)
+
+        it('shows the "no data" message', () => {
+          var text = $('.reactable-no-data').text();
+          expect(text).to.eq('No matching records found.');
+        });
+      });
+
+      context('when initialized with an empty array for `data` prop', () => {
+        before(function() {
+            this.component = ReactDOM.render(
+                <Reactable.Table data={[]} className="table" id="table" columns={['State', 'Description', 'Tag']} noDataText="No matching records found."></Reactable.Table>,
+                ReactableTestUtils.testNode()
+            );
+        });
+
+        after(ReactableTestUtils.resetTestEnvironment);
+
+        it('shows the "no data" message', () => {
+          var $text = $('.reactable-no-data').text();
+          expect($text).to.eq('No matching records found.');
+        });
+      });
+    })
 });


### PR DESCRIPTION
Adds a UX enhancement that shows text inside the table when there is no data to display. 

This text is shown either if the table is initialized without any data or if the table is filterable and there are no matches with the current filter input text.

The content of the message is configurable with the `noDataText` prop and provides a default message in `defaultProps`.