### PR TITLE
Add basic noDataText taken from glittershark

### DIFF
--- a/src/reactable/lib/filter_props_from.jsx
+++ b/src/reactable/lib/filter_props_from.jsx
@@ -8,7 +8,8 @@ const internalProps = {
     itemsPerPage: true,
     childNode: true,
     data: true,
-    children: true
+    children: true,
+    noDataText: 'No matches.'
 };
 
 export function filterPropsFrom(baseProps) {

--- a/src/reactable/table.jsx
+++ b/src/reactable/table.jsx
@@ -417,6 +417,8 @@ export class Table extends React.Component {
         // Manually transfer props
         let props = filterPropsFrom(this.props);
 
+        let noDataText = (this.props.noDataText ? <span className="reactable-no-data">{this.props.noDataText}</span> : null);
+
         return <table {...props}>
             {columns && columns.length > 0 ?
              <Thead columns={columns}
@@ -432,7 +434,7 @@ export class Table extends React.Component {
                  key="thead"/>
              : null}
             <tbody className="reactable-data" key="tbody">
-                {currentChildren}
+                {currentChildren.length > 0 ? currentChildren : noDataText}
             </tbody>
             {pagination === true ?
              <Paginator colSpan={columns.length}


### PR DESCRIPTION
NOTE: the work in the table.jsx file is taken directly from later
versions of Reactable and is not my work. The addition of noDataText
to the internal_props in filter_props_from is my own choice--I
always prefer to have a message if no results are present.