### PR TITLE
Fix noDataText markup

### DIFF
--- a/src/reactable/table.jsx
+++ b/src/reactable/table.jsx
@@ -420,7 +420,7 @@ export class Table extends React.Component {
         // Manually transfer props
         let props = filterPropsFrom(this.props);
 
-        let noDataText = this.props.noDataText ? <span className="reactable-no-data">{this.props.noDataText}</span> : null;
+        let noDataText = this.props.noDataText ? <tr className="reactable-no-data"><td colSpan={columns.length}>{this.props.noDataText}</td></tr> : null;
 
         return <table {...props}>
             {columns && columns.length > 0 ?


### PR DESCRIPTION
Implementing this in our project off of master, I noticed I was getting this message:

```
Warning: validateDOMNesting(...): <span> cannot appear as a child of <tbody>. See Table > tbody > span.
```

which is definitely my bad.

Solution was to update the noDataText markup so that it's valid table child, i.e.:
```html
<tr><td>No matching records found.</td></tr>
```