### PR TITLE
Add onSort callback passing via props 

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,3 +438,52 @@ var table = ReactDOM.render(
   document.getElementById('table')
 );
 ```
+
+### Events
+
+If you want to have follow up actions or state updates to come after a table sort
+you can use the prop `onSort` to provide a callback that will return a `currentSort`
+object. This by default will be null and not fire a callback.
+
+The `currentSort` object contains the column name and direction :
+
+```JSON
+{
+  column: 'Name',
+  direction: -1
+}
+```
+
+in JSX this looks like
+
+```jsx
+
+callback(currentSort) {
+  console.log('Column name: ', currentSort.column);
+},
+
+render() {
+  return (
+    <Table className="table" id="table" data={[
+        { Name: 'Lee Salminen', Age: '23', Position: 'Programmer'},
+        { Name: 'Griffin Smith', Age: '18', Position: 'Engineer'},
+        { Name: 'Ian Zhang', Age: '28', Position: 'Developer'}
+    ]}
+    sortable={[
+        {
+            column: 'Name',
+            sortFunction: function(a, b){
+                // Sort by last name
+                var nameA = a.split(' ');
+                var nameB = b.split(' ');
+                return nameA[1].localeCompare(nameB[1]);
+            }
+        },
+        'Age',
+        'Position'
+    ]}
+    defaultSort={{column: 'Age', direction: 'desc'}}
+    onSort={ this.callBack }/>
+  );
+}
+```

--- a/build/reactable.js
+++ b/build/reactable.js
@@ -1283,6 +1283,10 @@ window.ReactDOM["default"] = window.ReactDOM;
                 // Set the current sort and pass it to the sort function
                 this.setState({ currentSort: currentSort });
                 this.sortByCurrentSort();
+
+                if (this.props.onSort) {
+                    this.props.onSort(currentSort);
+                }
             }
         }, {
             key: 'render',
@@ -1391,6 +1395,16 @@ window.ReactDOM["default"] = window.ReactDOM;
                 // Manually transfer props
                 var props = (0, _libFilter_props_from.filterPropsFrom)(this.props);
 
+                var noDataText = this.props.noDataText ? _react['default'].createElement(
+                    'tr',
+                    { className: 'reactable-no-data' },
+                    _react['default'].createElement(
+                        'td',
+                        { colSpan: columns.length },
+                        this.props.noDataText
+                    )
+                ) : null;
+
                 return _react['default'].createElement(
                     'table',
                     props,
@@ -1408,7 +1422,7 @@ window.ReactDOM["default"] = window.ReactDOM;
                     _react['default'].createElement(
                         'tbody',
                         { className: 'reactable-data', key: 'tbody' },
-                        currentChildren
+                        currentChildren.length > 0 ? currentChildren : noDataText
                     ),
                     pagination === true ? _react['default'].createElement(_paginator.Paginator, { colSpan: columns.length,
                         pageButtonLimit: pageButtonLimit,

--- a/build/tests/reactable_test.js
+++ b/build/tests/reactable_test.js
@@ -1649,6 +1649,50 @@
                     ReactableTestUtils.expectRowText(2, ['Third']);
                 });
             });
+
+            describe('sorts and calls onSort callback via props', function () {
+                var sortColumn = null;
+
+                var callback = function callback(sortObject) {
+                    console.log(sortObject);
+                    sortColumn = sortObject.column;
+                };
+
+                before(function () {
+                    ReactDOM.render(React.createElement(Reactable.Table, { className: 'table', id: 'table', data: [{ 'Rank': React.createElement(
+                                'span',
+                                { className: '3' },
+                                'Third'
+                            ) }, { 'Rank': React.createElement(
+                                'span',
+                                { className: '1' },
+                                'First'
+                            ) }, { 'Rank': React.createElement(
+                                'span',
+                                { className: '2' },
+                                'Second'
+                            ) }],
+                        columns: [{
+                            key: 'Rank', sortable: function sortable(a, b) {
+                                // sort based on classname
+                                return a.props.className.localeCompare(b.props.className);
+                            }
+                        }],
+                        onSort: callback }), ReactableTestUtils.testNode());
+                });
+
+                after(function () {
+                    ReactableTestUtils.resetTestEnvironment();
+                });
+
+                it('returns currentSort object to callback for utilization', function () {
+                    var sortHeader = $('#table thead tr.reactable-column-header th')[0];
+                    ReactTestUtils.Simulate.click(sortHeader);
+
+                    console.log(sortColumn);
+                    expect(sortColumn).to.equal('Rank');
+                });
+            });
         });
 
         describe('filtering', function () {
@@ -2149,6 +2193,143 @@
 
             it('calls the callbacks on click', function () {
                 expect(this.clicked).to.eq(true);
+            });
+        });
+
+        describe('table with no data', function () {
+            context('when noDataText prop is null', function () {
+                before(function () {
+                    this.component = ReactDOM.render(React.createElement(Reactable.Table, { data: [], columns: ['State', 'Description', 'Tag'] }), ReactableTestUtils.testNode());
+                });
+
+                after(ReactableTestUtils.resetTestEnvironment);
+
+                it('does not render the reactable-no-data element', function () {
+                    expect($('.reactable-no-data').length).to.eq(0);
+                });
+            });
+
+            context('when initialized without <Tr>s', function () {
+                before(function () {
+                    this.component = ReactDOM.render(React.createElement(Reactable.Table, { className: 'table', id: 'table', columns: ['State', 'Description', 'Tag'], noDataText: 'No matching records found.' }), ReactableTestUtils.testNode());
+                });
+
+                after(ReactableTestUtils.resetTestEnvironment);
+
+                it('shows the "no data" message', function () {
+                    var $text = $('.reactable-no-data').text();
+                    expect($text).to.eq('No matching records found.');
+                });
+            });
+
+            context('when filtered without any matches', function () {
+                before(function () {
+                    this.component = ReactDOM.render(React.createElement(
+                        Reactable.Table,
+                        { className: 'table', id: 'table',
+                            filterable: ['State', 'Tag'],
+                            filterPlaceholder: 'Filter Results',
+                            filterBy: 'xxxxx',
+                            noDataText: 'No matching records found.',
+                            columns: ['State', 'Description', 'Tag'] },
+                        React.createElement(
+                            Reactable.Tr,
+                            null,
+                            React.createElement(
+                                Reactable.Td,
+                                { column: 'State' },
+                                'New York'
+                            ),
+                            React.createElement(
+                                Reactable.Td,
+                                { column: 'Description' },
+                                'this is some text'
+                            ),
+                            React.createElement(
+                                Reactable.Td,
+                                { column: 'Tag' },
+                                'new'
+                            )
+                        ),
+                        React.createElement(
+                            Reactable.Tr,
+                            null,
+                            React.createElement(
+                                Reactable.Td,
+                                { column: 'State' },
+                                'New Mexico'
+                            ),
+                            React.createElement(
+                                Reactable.Td,
+                                { column: 'Description' },
+                                'lorem ipsum'
+                            ),
+                            React.createElement(
+                                Reactable.Td,
+                                { column: 'Tag' },
+                                'old'
+                            )
+                        ),
+                        React.createElement(
+                            Reactable.Tr,
+                            null,
+                            React.createElement(
+                                Reactable.Td,
+                                { column: 'State' },
+                                'Colorado'
+                            ),
+                            React.createElement(
+                                Reactable.Td,
+                                { column: 'Description' },
+                                'new description that shouldnt match filter'
+                            ),
+                            React.createElement(
+                                Reactable.Td,
+                                { column: 'Tag' },
+                                'old'
+                            )
+                        ),
+                        React.createElement(
+                            Reactable.Tr,
+                            null,
+                            React.createElement(
+                                Reactable.Td,
+                                { column: 'State' },
+                                'Alaska'
+                            ),
+                            React.createElement(
+                                Reactable.Td,
+                                { column: 'Description' },
+                                'bacon'
+                            ),
+                            React.createElement(
+                                Reactable.Td,
+                                { column: 'Tag' },
+                                'renewed'
+                            )
+                        )
+                    ), ReactableTestUtils.testNode());
+                });
+
+                after(ReactableTestUtils.resetTestEnvironment);
+
+                it('shows the "no data" message', function () {
+                    var text = $('.reactable-no-data').text();
+                    expect(text).to.eq('No matching records found.');
+                });
+            });
+
+            context('when initialized with an empty array for `data` prop', function () {
+                before(function () {
+                    this.component = ReactDOM.render(React.createElement(Reactable.Table, { data: [], className: 'table', id: 'table', columns: ['State', 'Description', 'Tag'], noDataText: 'No matching records found.' }), ReactableTestUtils.testNode());
+                });
+
+                after(ReactableTestUtils.resetTestEnvironment);
+
+                it('shows the "no data" message', function () {
+                    var $text = $('.reactable-no-data').text();
+                    expect($text).to.eq('No matching records found.');
+                });
             });
         });
     });

--- a/lib/reactable/table.js
+++ b/lib/reactable/table.js
@@ -336,6 +336,10 @@ var Table = (function (_React$Component) {
             // Set the current sort and pass it to the sort function
             this.setState({ currentSort: currentSort });
             this.sortByCurrentSort();
+
+            if (this.props.onSort) {
+                this.props.onSort(currentSort);
+            }
         }
     }, {
         key: 'render',
@@ -444,6 +448,16 @@ var Table = (function (_React$Component) {
             // Manually transfer props
             var props = (0, _libFilter_props_from.filterPropsFrom)(this.props);
 
+            var noDataText = this.props.noDataText ? _react2['default'].createElement(
+                'tr',
+                { className: 'reactable-no-data' },
+                _react2['default'].createElement(
+                    'td',
+                    { colSpan: columns.length },
+                    this.props.noDataText
+                )
+            ) : null;
+
             return _react2['default'].createElement(
                 'table',
                 props,
@@ -461,7 +475,7 @@ var Table = (function (_React$Component) {
                 _react2['default'].createElement(
                     'tbody',
                     { className: 'reactable-data', key: 'tbody' },
-                    currentChildren
+                    currentChildren.length > 0 ? currentChildren : noDataText
                 ),
                 pagination === true ? _react2['default'].createElement(_paginator.Paginator, { colSpan: columns.length,
                     pageButtonLimit: pageButtonLimit,

--- a/src/reactable/table.jsx
+++ b/src/reactable/table.jsx
@@ -299,7 +299,7 @@ export class Table extends React.Component {
         this.setState({ currentSort: currentSort });
         this.sortByCurrentSort();
 
-        if (this.props.onSort) {
+        if (typeof(this.props.onSort) === 'function') {
             this.props.onSort(currentSort);
         }
     }

--- a/src/reactable/table.jsx
+++ b/src/reactable/table.jsx
@@ -298,6 +298,10 @@ export class Table extends React.Component {
         // Set the current sort and pass it to the sort function
         this.setState({ currentSort: currentSort });
         this.sortByCurrentSort();
+
+        if (this.props.onSort) {
+            this.props.onSort(currentSort);
+        }
     }
 
     render() {

--- a/tests/reactable_test.jsx
+++ b/tests/reactable_test.jsx
@@ -1533,6 +1533,44 @@ describe('Reactable', function() {
                 ReactableTestUtils.expectRowText(2, ['Third']);
             });
         });
+    
+        describe('sorts and calls onSort callback via props', function(){
+            var sortColumn = null;
+
+            var callback = function(sortObject){
+                sortColumn = sortObject.column;
+            }
+
+            before(function() {
+                ReactDOM.render(
+                    <Reactable.Table className="table" id="table" data={[
+                        {'Rank': <span className="3">Third</span>},
+                        {'Rank': <span className="1">First</span>},
+                        {'Rank': <span className="2">Second</span>},
+                        ]}
+                        columns={[{
+                            key: 'Rank', sortable: function (a, b) {
+                                // sort based on classname
+                                return a.props.className.localeCompare(b.props.className);
+                            }
+                        }]} 
+                        onSort={ callback }/>,
+                    ReactableTestUtils.testNode()
+                );
+            });
+
+            after(function() {
+                ReactableTestUtils.resetTestEnvironment();
+            });
+
+            it('returns currentSort object to callback for utilization', function(){
+                var sortHeader = $('#table thead tr.reactable-column-header th')[0];
+                ReactTestUtils.Simulate.click(sortHeader);
+
+                expect(sortColumn).to.equal('Rank');
+            });
+        });
+
     });
 
     describe('filtering', function() {


### PR DESCRIPTION
I saw added onSort event as prop #211

And I need this functionality for my project pretty severely. So I wrote a test and updated the documentation for it under Events section. 

I'm not sure why the noDataText stuff is in there? I didn't touch that.