### PR TITLE
Sort by fixes

### DIFF
--- a/build/reactable.js
+++ b/build/reactable.js
@@ -1181,9 +1181,9 @@ window.ReactDOM["default"] = window.ReactDOM;
         }, {
             key: 'updateCurrentSort',
             value: function updateCurrentSort(sortBy) {
-                if (sortBy !== false && sortBy.column !== this.state.currentSort.column && sortBy.direction !== this.state.currentSort.direction) {
+                if (sortBy !== false && (sortBy.column !== this.state.currentSort.column || sortBy.direction !== this.state.currentSort.direction)) {
 
-                    this.setState({ currentSort: this.getCurrentSort(sortBy) });
+                    this.setState.currentSort = this.getCurrentSort(sortBy);
                 }
             }
         }, {

--- a/build/reactable.js
+++ b/build/reactable.js
@@ -1183,7 +1183,7 @@ window.ReactDOM["default"] = window.ReactDOM;
             value: function updateCurrentSort(sortBy) {
                 if (sortBy !== false && (sortBy.column !== this.state.currentSort.column || sortBy.direction !== this.state.currentSort.direction)) {
 
-                    this.setState.currentSort = this.getCurrentSort(sortBy);
+                    this.state.currentSort = this.getCurrentSort(sortBy);
                 }
             }
         }, {

--- a/lib/reactable/table.js
+++ b/lib/reactable/table.js
@@ -234,9 +234,9 @@ var Table = (function (_React$Component) {
     }, {
         key: 'updateCurrentSort',
         value: function updateCurrentSort(sortBy) {
-            if (sortBy !== false && sortBy.column !== this.state.currentSort.column && sortBy.direction !== this.state.currentSort.direction) {
+            if (sortBy !== false && (sortBy.column !== this.state.currentSort.column || sortBy.direction !== this.state.currentSort.direction)) {
 
-                this.setState({ currentSort: this.getCurrentSort(sortBy) });
+                this.setState.currentSort = this.getCurrentSort(sortBy);
             }
         }
     }, {

--- a/lib/reactable/table.js
+++ b/lib/reactable/table.js
@@ -236,7 +236,7 @@ var Table = (function (_React$Component) {
         value: function updateCurrentSort(sortBy) {
             if (sortBy !== false && (sortBy.column !== this.state.currentSort.column || sortBy.direction !== this.state.currentSort.direction)) {
 
-                this.setState.currentSort = this.getCurrentSort(sortBy);
+                this.state.currentSort = this.getCurrentSort(sortBy);
             }
         }
     }, {

--- a/src/reactable/table.jsx
+++ b/src/reactable/table.jsx
@@ -194,10 +194,10 @@ export class Table extends React.Component {
 
     updateCurrentSort(sortBy) {
         if (sortBy !== false &&
-            sortBy.column !== this.state.currentSort.column &&
-                sortBy.direction !== this.state.currentSort.direction) {
+            (sortBy.column !== this.state.currentSort.column ||
+                sortBy.direction !== this.state.currentSort.direction)) {
 
-            this.setState({ currentSort: this.getCurrentSort(sortBy) });
+            this.setState.currentSort = this.getCurrentSort(sortBy)
         }
     }
 

--- a/src/reactable/table.jsx
+++ b/src/reactable/table.jsx
@@ -197,7 +197,7 @@ export class Table extends React.Component {
             (sortBy.column !== this.state.currentSort.column ||
                 sortBy.direction !== this.state.currentSort.direction)) {
 
-            this.setState.currentSort = this.getCurrentSort(sortBy)
+            this.state.currentSort = this.getCurrentSort(sortBy)
         }
     }
 


### PR DESCRIPTION
2 things I fixed in updateCurrentSort():
- If it was only column or direction that changed, it didn't update.
- setState() did not write the state straightforward, so when sortByCurrentSort() was called, it was taking the old state.