### PR TITLE
Allow to filter by colum: value

### DIFF
--- a/src/reactable/filterer.jsx
+++ b/src/reactable/filterer.jsx
@@ -7,11 +7,18 @@ export class FiltererInput extends React.Component {
     }
 
     render() {
+      let value = this.props.value
+
+      if (typeof(value) != 'string') {
+        let col = Object.keys(this.props.value).toString()
+        let val = Object.keys(this.props.value).map(key => this.props.value[key]).toString()
+         value = col+': '+val
+      }
         return (
             <input type="text"
                 className="reactable-filter-input"
                 placeholder={this.props.placeholder}
-                value={this.props.value}
+                value={value}
                 onKeyUp={this.onChange.bind(this)}
                 onChange={this.onChange.bind(this)} />
         );
@@ -35,4 +42,3 @@ export class Filterer extends React.Component {
         );
     }
 };
-

--- a/src/reactable/table.jsx
+++ b/src/reactable/table.jsx
@@ -215,6 +215,7 @@ export class Table extends React.Component {
     }
 
     applyFilter(filter, children) {
+      if(typeof(filter) === 'string'){
         // Helper function to apply filter text to a list of table rows
         filter = filter.toLowerCase();
         let matchedChildren = [];
@@ -236,7 +237,42 @@ export class Table extends React.Component {
         }
 
         return matchedChildren;
+    } else {
+      let cols = Object.keys(filter)
+      filter = cols.map(key => filter[key])
+      filter = filter.toString().toLowerCase();
+
+      let matchedChildren = [];
+      let filterColumn = cols.toString()
+
+      for (let i = 0; i < children.length; i++) {
+          let data = children[i].props.data;
+
+          if (
+              typeof(data[filterColumn]) !== 'undefined' &&
+                  extractDataFrom(data, filterColumn).toString().toLowerCase().indexOf(filter) > -1
+          ) {
+              matchedChildren.push(children[i]);
+              break;
+          }
+      }
+
+      return matchedChildren;
     }
+  }
+
+  onFilter(filter) {
+      if( typeof(filter) === 'string' && filter.indexOf(':') != -1) {
+        let filterObj = {}
+        filter = filter.split(':')
+        let col = filter[0].trim()
+        let val = filter[1].trim()
+        filterObj[col] = val
+        filter = filterObj
+      }
+
+    this.setState({ filter: filter });
+  }
 
     sortByCurrentSort() {
         // Apply a sort function according to the current sort in the state.
@@ -430,9 +466,7 @@ export class Table extends React.Component {
             {columns && columns.length > 0 ?
              <Thead columns={columns}
                  filtering={filtering}
-                 onFilter={filter => {
-                     this.setState({ filter: filter });
-                 }}
+                 onFilter={this.onFilter.bind(this)}
                  filterPlaceholder={this.props.filterPlaceholder}
                  currentFilter={this.state.filter}
                  sort={this.state.currentSort}


### PR DESCRIPTION
This Branch improves the way filterBy workes, by allowing it to be
set with and hash like {'Column': 'search query'}  programatically.

Another improvement, that still needs to be touched is the ability to do
the same from the search box in a form of 'Column: search query' that will be
split by the ':' and use each side as column to filter, and value.