### PR TITLE
Add onContextMenu support by handleContextMenu

### DIFF
--- a/src/reactable/td.jsx
+++ b/src/reactable/td.jsx
@@ -10,10 +10,17 @@ export class Td extends React.Component {
         }
     }
 
+    handleContextMenu(e){
+        if (typeof this.props.handleContextMenu === 'function') {
+            return this.props.handleContextMenu(e, this);
+        }
+    }
+
     render() {
         var tdProps = {
             className: this.props.className,
-            onClick: this.handleClick.bind(this)
+            onClick: this.handleClick.bind(this),
+            onContextMenu: this.handleContextMenu.bind(this)
         };
 
         // Attach any properties on the column to this Td object to allow things like custom event handlers


### PR DESCRIPTION
Hi,

Like handleClick, I needed to handle onContextMenu event from react in Td component. I added this handleContextMenu and in works fine for me. Please take a look and I'd appreciate if this can be added.

```jsx
// sample usage
<Td column="name" data={this.props.name}
    handleContextMenu={this.openCustomContextMenu.bind(this, "arg1", "arg2")} />
```