### PR TITLE
issue #237 - column attribute ignored when <Td> has children

### DIFF
--- a/build/reactable.js
+++ b/build/reactable.js
@@ -727,16 +727,31 @@ window.ReactDOM["default"] = window.ReactDOM;
                 // Can't use React.Children.map since that doesn't return a proper array
                 var columns = [];
                 _react['default'].Children.forEach(component.props.children, function (th) {
-                    if (typeof th.props.children === 'string') {
-                        columns.push(th.props.children);
-                    } else if (typeof th.props.column === 'string') {
-                        columns.push({
-                            key: th.props.column,
-                            label: th.props.children,
-                            props: (0, _libFilter_props_from.filterPropsFrom)(th.props)
-                        });
-                    } else {
+                    var column = {};
+                    if (typeof th.props !== 'undefined') {
+                        column.props = (0, _libFilter_props_from.filterPropsFrom)(th.props);
+
+                        // use the content as the label & key
+                        if (typeof th.props.children !== 'undefined') {
+                            column.label = th.props.children;
+                            column.key = column.label;
+                        }
+
+                        // the key in the column attribute supersedes the one defined previously
+                        if (typeof th.props.column === 'string') {
+                            column.key = th.props.column;
+
+                            // in case we don't have a label yet
+                            if (typeof column.label === 'undefined') {
+                                column.label = column.key;
+                            }
+                        }
+                    }
+
+                    if (typeof column.key === 'undefined') {
                         throw new TypeError('<th> must have either a "column" property or a string ' + 'child');
+                    } else {
+                        columns.push(column);
                     }
                 });
 

--- a/build/tests/reactable_test.js
+++ b/build/tests/reactable_test.js
@@ -765,39 +765,74 @@
         });
 
         describe('specifying columns using a <Thead>', function () {
-            before(function () {
-                ReactDOM.render(React.createElement(
-                    Reactable.Table,
-                    { id: 'table', data: [{ Name: Reactable.unsafe('<span id="griffins-name">Griffin Smith</span>'), Age: '18' }, { Age: '28', Position: Reactable.unsafe('<span id="who-knows-job">Developer</span>') }, { Age: '23', Name: Reactable.unsafe('<span id="lees-name">Lee Salminen</span>') }] },
-                    React.createElement(
-                        Reactable.Thead,
-                        null,
+            describe('and an element for the column title', function () {
+                before(function () {
+                    ReactDOM.render(React.createElement(
+                        Reactable.Table,
+                        { id: 'table', data: [{ Name: Reactable.unsafe('<span id="griffins-name">Griffin Smith</span>'), Age: '18' }, { Age: '28', Position: Reactable.unsafe('<span id="who-knows-job">Developer</span>') }, { Age: '23', Name: Reactable.unsafe('<span id="lees-name">Lee Salminen</span>') }] },
                         React.createElement(
-                            Reactable.Th,
-                            { column: 'Name', id: 'my-name' },
+                            Reactable.Thead,
+                            null,
                             React.createElement(
-                                'strong',
-                                null,
+                                Reactable.Th,
+                                { column: 'Name', id: 'my-name' },
+                                React.createElement(
+                                    'strong',
+                                    null,
+                                    'name'
+                                )
+                            )
+                        )
+                    ), ReactableTestUtils.testNode());
+                });
+
+                after(ReactableTestUtils.resetTestEnvironment);
+
+                it('renders only the columns in the Thead', function () {
+                    expect($('#table tbody tr:first td')).to.exist;
+                    expect($('#table thead tr:first th')).to.exist;
+                });
+
+                it('renders the contents of the Th', function () {
+                    expect($('#table>thead>tr>th>strong')).to.exist;
+                });
+
+                it('passes through the properties of the Th', function () {
+                    expect($('#table>thead>tr>th')).to.have.id('my-name');
+                });
+            });
+
+            describe('and a string for the column title', function () {
+                before(function () {
+                    ReactDOM.render(React.createElement(
+                        Reactable.Table,
+                        { id: 'table', data: [{ Name: Reactable.unsafe('<span id="griffins-name">Griffin Smith</span>'), Age: '18' }, { Age: '28', Position: Reactable.unsafe('<span id="who-knows-job">Developer</span>') }, { Age: '23', Name: Reactable.unsafe('<span id="lees-name">Lee Salminen</span>') }] },
+                        React.createElement(
+                            Reactable.Thead,
+                            null,
+                            React.createElement(
+                                Reactable.Th,
+                                { column: 'Name', id: 'my-name' },
                                 'name'
                             )
                         )
-                    )
-                ), ReactableTestUtils.testNode());
-            });
+                    ), ReactableTestUtils.testNode());
+                });
 
-            after(ReactableTestUtils.resetTestEnvironment);
+                after(ReactableTestUtils.resetTestEnvironment);
 
-            it('renders only the columns in the Thead', function () {
-                expect($('#table tbody tr:first td')).to.exist;
-                expect($('#table thead tr:first th')).to.exist;
-            });
+                it('renders only the columns in the Thead', function () {
+                    expect($('#table tbody tr:first td')).to.exist;
+                    expect($('#table thead tr:first th')).to.exist;
+                });
 
-            it('renders the contents of the Th', function () {
-                expect($('#table>thead>tr>th>strong')).to.exist;
-            });
+                it('renders the contents of the Th', function () {
+                    expect($('#table>thead>tr>th')).to.exist;
+                });
 
-            it('passes through the properties of the Th', function () {
-                expect($('#table>thead>tr>th')).to.have.id('my-name');
+                it('passes through the properties of the Th', function () {
+                    expect($('#table>thead>tr>th')).to.have.id('my-name');
+                });
             });
         });
 
@@ -1078,6 +1113,30 @@
 
                 it('renders all rows', function () {
                     expect($('#table tbody.reactable-data tr').length).to.equal(9);
+                });
+            });
+
+            describe('onPageChange hook', function () {
+                var currentPage = undefined;
+                var callback = function callback(page) {
+                    currentPage = page;
+                };
+                before(function () {
+                    ReactDOM.render(React.createElement(Reactable.Table, { className: 'table', id: 'table', data: [{ 'Name': 'Griffin Smith', 'Age': '18' }, { 'Age': '23', 'Name': 'Lee Salminen' }, { 'Age': '28', 'Position': 'Developer' }, { 'Name': 'Griffin Smith', 'Age': '18' }, { 'Age': '23', 'Name': 'Test Person' }, { 'Name': 'Ian Zhang', 'Age': '28', 'Position': 'Developer' }, { 'Name': 'Griffin Smith', 'Age': '18', 'Position': 'Software Developer' }, { 'Age': '23', 'Name': 'Lee Salminen' }, { 'Age': '28', 'Position': 'Developer' }], itemsPerPage: 4, onPageChange: callback }), ReactableTestUtils.testNode());
+                });
+
+                after(ReactableTestUtils.resetTestEnvironment);
+
+                it('emits the number of the currently selected page (zero based) when onPageChange event is triggered', function () {
+                    var page1 = $('#table tbody.reactable-pagination a.reactable-page-button')[0];
+                    var page2 = $('#table tbody.reactable-pagination a.reactable-page-button')[1];
+                    var page3 = $('#table tbody.reactable-pagination a.reactable-page-button')[2];
+                    ReactTestUtils.Simulate.click(page2);
+                    expect(currentPage).to.equal(1);
+                    ReactTestUtils.Simulate.click(page1);
+                    expect(currentPage).to.equal(0);
+                    ReactTestUtils.Simulate.click(page3);
+                    expect(currentPage).to.equal(2);
                 });
             });
         });

--- a/lib/reactable/thead.js
+++ b/lib/reactable/thead.js
@@ -108,16 +108,31 @@ var Thead = (function (_React$Component) {
             // Can't use React.Children.map since that doesn't return a proper array
             var columns = [];
             _react2['default'].Children.forEach(component.props.children, function (th) {
-                if (typeof th.props.children === 'string') {
-                    columns.push(th.props.children);
-                } else if (typeof th.props.column === 'string') {
-                    columns.push({
-                        key: th.props.column,
-                        label: th.props.children,
-                        props: (0, _libFilter_props_from.filterPropsFrom)(th.props)
-                    });
-                } else {
+                var column = {};
+                if (typeof th.props !== 'undefined') {
+                    column.props = (0, _libFilter_props_from.filterPropsFrom)(th.props);
+
+                    // use the content as the label & key
+                    if (typeof th.props.children !== 'undefined') {
+                        column.label = th.props.children;
+                        column.key = column.label;
+                    }
+
+                    // the key in the column attribute supersedes the one defined previously
+                    if (typeof th.props.column === 'string') {
+                        column.key = th.props.column;
+
+                        // in case we don't have a label yet
+                        if (typeof column.label === 'undefined') {
+                            column.label = column.key;
+                        }
+                    }
+                }
+
+                if (typeof column.key === 'undefined') {
                     throw new TypeError('<th> must have either a "column" property or a string ' + 'child');
+                } else {
+                    columns.push(column);
                 }
             });
 

--- a/src/reactable/thead.jsx
+++ b/src/reactable/thead.jsx
@@ -8,18 +8,33 @@ export class Thead extends React.Component {
         // Can't use React.Children.map since that doesn't return a proper array
         let columns = [];
         React.Children.forEach(component.props.children, th => {
-            if (typeof th.props.children === 'string') {
-                columns.push(th.props.children);
-            } else if (typeof th.props.column === 'string') {
-                columns.push({
-                    key: th.props.column,
-                    label: th.props.children,
-                    props: filterPropsFrom(th.props)
-                });
-            } else {
+            var column = {};
+            if (typeof th.props !== 'undefined') {
+                column.props = filterPropsFrom(th.props);
+
+                // use the content as the label & key
+                if (typeof th.props.children !== 'undefined') {
+                    column.label = th.props.children;
+                    column.key = column.label;
+                }
+
+                // the key in the column attribute supersedes the one defined previously
+                if (typeof th.props.column === 'string') {
+                    column.key = th.props.column;
+
+                    // in case we don't have a label yet
+                    if (typeof column.label === 'undefined') {
+                        column.label = column.key;
+                    }
+                }
+            }
+
+            if (typeof column.key === 'undefined') {
                 throw new TypeError(
                     '<th> must have either a "column" property or a string ' +
-                        'child');
+                    'child');
+            } else {
+                columns.push(column);
             }
         });
 

--- a/tests/reactable_test.jsx
+++ b/tests/reactable_test.jsx
@@ -561,38 +561,77 @@ describe('Reactable', function() {
     });
 
     describe('specifying columns using a <Thead>', function() {
-        before(function() {
-            ReactDOM.render(
-                <Reactable.Table id="table" data={[
+        describe('and an element for the column title', function() {
+            before(function() {
+                ReactDOM.render(
+                    <Reactable.Table id="table" data={[
                     { Name: Reactable.unsafe('<span id="griffins-name">Griffin Smith</span>'), Age: '18'},
                     { Age: '28', Position: Reactable.unsafe('<span id="who-knows-job">Developer</span>')},
                     { Age: '23', Name: Reactable.unsafe('<span id="lees-name">Lee Salminen</span>')},
                 ]}>
-                    <Reactable.Thead>
-                        <Reactable.Th column="Name" id="my-name">
-                            <strong>name</strong>
-                        </Reactable.Th>
-                    </Reactable.Thead>
-                </Reactable.Table>,
-                ReactableTestUtils.testNode()
-            );
+                        <Reactable.Thead>
+                            <Reactable.Th column="Name" id="my-name">
+                                <strong>name</strong>
+                            </Reactable.Th>
+                        </Reactable.Thead>
+                    </Reactable.Table>,
+                    ReactableTestUtils.testNode()
+                );
+            });
+
+            after(ReactableTestUtils.resetTestEnvironment);
+
+            it('renders only the columns in the Thead', function() {
+                expect($('#table tbody tr:first td')).to.exist;
+                expect($('#table thead tr:first th')).to.exist;
+            });
+
+            it('renders the contents of the Th', function() {
+                expect($('#table>thead>tr>th>strong')).to.exist;
+            });
+
+            it('passes through the properties of the Th', function() {
+                expect($('#table>thead>tr>th')).to.have.id('my-name')
+            });
+
         });
 
-        after(ReactableTestUtils.resetTestEnvironment);
+        describe('and a string for the column title', function() {
+            before(function() {
+                ReactDOM.render(
+                    <Reactable.Table id="table" data={[
+                    { Name: Reactable.unsafe('<span id="griffins-name">Griffin Smith</span>'), Age: '18'},
+                    { Age: '28', Position: Reactable.unsafe('<span id="who-knows-job">Developer</span>')},
+                    { Age: '23', Name: Reactable.unsafe('<span id="lees-name">Lee Salminen</span>')},
+                ]}>
+                        <Reactable.Thead>
+                            <Reactable.Th column="Name" id="my-name">
+                                name
+                            </Reactable.Th>
+                        </Reactable.Thead>
+                    </Reactable.Table>,
+                    ReactableTestUtils.testNode()
+                );
+            });
 
-        it('renders only the columns in the Thead', function() {
-            expect($('#table tbody tr:first td')).to.exist;
-            expect($('#table thead tr:first th')).to.exist;
-        });
+            after(ReactableTestUtils.resetTestEnvironment);
 
-        it('renders the contents of the Th', function() {
-            expect($('#table>thead>tr>th>strong')).to.exist;
-        });
+            it('renders only the columns in the Thead', function() {
+                expect($('#table tbody tr:first td')).to.exist;
+                expect($('#table thead tr:first th')).to.exist;
+            });
 
-        it('passes through the properties of the Th', function() {
-            expect($('#table>thead>tr>th')).to.have.id('my-name')
-        });
+            it('renders the contents of the Th', function() {
+                expect($('#table>thead>tr>th')).to.exist;
+            });
+
+            it('passes through the properties of the Th', function() {
+                expect($('#table>thead>tr>th')).to.have.id('my-name')
+            });
+
+        })
     });
+
 
     describe('unsafe() strings', function() {
         context('in the <Table> directly', function() {


### PR DESCRIPTION
  - fix 'key' attribute for columns when a custom `Thead` is used