### PR TITLE
Adds on onKeyDown handler to Th to sort on enter

### DIFF
--- a/build/reactable.js
+++ b/build/reactable.js
@@ -660,6 +660,13 @@ window.ReactDOM["default"] = window.ReactDOM;
                 this.props.onSort(column.key);
             }
         }, {
+            key: 'handleKeyDownTh',
+            value: function handleKeyDownTh(column, event) {
+                if (event.keyCode === 13) {
+                    this.props.onSort(column.key);
+                }
+            }
+        }, {
             key: 'render',
             value: function render() {
                 // Declare the list of Ths
@@ -696,6 +703,7 @@ window.ReactDOM["default"] = window.ReactDOM;
                             className: thClass,
                             key: index,
                             onClick: this.handleClickTh.bind(this, column),
+                            onKeyDown: this.handleKeyDownTh.bind(this, column),
                             role: 'button',
                             tabIndex: '0' }),
                         column.label

--- a/build/tests/reactable_test.js
+++ b/build/tests/reactable_test.js
@@ -1223,6 +1223,30 @@
                     // Make sure the headers have the right classes
                     expect($(nameHeader)).to.have['class']('reactable-header-sort-desc');
                 });
+
+                it('sorts by last name in ascending order by enter keydown', function () {
+                    var nameHeader = $('#table thead tr.reactable-column-header th')[0];
+                    ReactTestUtils.Simulate.keyDown(nameHeader, { keyCode: 13 });
+
+                    ReactableTestUtils.expectRowText(0, ['Lee Salminen', '23', 'Programmer']);
+                    ReactableTestUtils.expectRowText(1, ['Griffin Smith', '18', 'Engineer']);
+                    ReactableTestUtils.expectRowText(2, ['Ian Zhang', '28', 'Developer']);
+
+                    // Make sure the headers have the right classes
+                    expect($(nameHeader)).to.have['class']('reactable-header-sort-asc');
+                });
+
+                it('does not sort on non-enter keydown', function () {
+                    var nameHeader = $('#table thead tr.reactable-column-header th')[0];
+                    ReactTestUtils.Simulate.keyDown(nameHeader, { keyCode: 10 });
+
+                    ReactableTestUtils.expectRowText(0, ['Lee Salminen', '23', 'Programmer']);
+                    ReactableTestUtils.expectRowText(1, ['Griffin Smith', '18', 'Engineer']);
+                    ReactableTestUtils.expectRowText(2, ['Ian Zhang', '28', 'Developer']);
+
+                    // Make sure the headers have the right classes
+                    expect($(nameHeader)).to.have['class']('reactable-header-sort-asc');
+                });
             });
 
             describe('passing `true` to sortable', function () {

--- a/lib/reactable/thead.js
+++ b/lib/reactable/thead.js
@@ -41,6 +41,13 @@ var Thead = (function (_React$Component) {
             this.props.onSort(column.key);
         }
     }, {
+        key: 'handleKeyDownTh',
+        value: function handleKeyDownTh(column, event) {
+            if (event.keyCode === 13) {
+                this.props.onSort(column.key);
+            }
+        }
+    }, {
         key: 'render',
         value: function render() {
             // Declare the list of Ths
@@ -77,6 +84,7 @@ var Thead = (function (_React$Component) {
                         className: thClass,
                         key: index,
                         onClick: this.handleClickTh.bind(this, column),
+                        onKeyDown: this.handleKeyDownTh.bind(this, column),
                         role: 'button',
                         tabIndex: '0' }),
                     column.label

--- a/src/reactable/thead.jsx
+++ b/src/reactable/thead.jsx
@@ -45,6 +45,12 @@ export class Thead extends React.Component {
         this.props.onSort(column.key);
     }
 
+    handleKeyDownTh(column, event) {
+      if (event.keyCode === 13) {
+        this.props.onSort(column.key);
+      }
+    }
+
     render() {
         // Declare the list of Ths
         var Ths = [];
@@ -83,6 +89,7 @@ export class Thead extends React.Component {
                     className={thClass}
                     key={index}
                     onClick={this.handleClickTh.bind(this, column)}
+                    onKeyDown={this.handleKeyDownTh.bind(this, column)}
                     role="button"
                     tabIndex="0">
                     {column.label}

--- a/tests/reactable_test.jsx
+++ b/tests/reactable_test.jsx
@@ -1123,6 +1123,30 @@ describe('Reactable', function() {
                 // Make sure the headers have the right classes
                 expect($(nameHeader)).to.have.class('reactable-header-sort-desc');
             });
+
+            it('sorts by last name in ascending order by enter keydown', function(){
+                var nameHeader = $('#table thead tr.reactable-column-header th')[0];
+                ReactTestUtils.Simulate.keyDown(nameHeader, {keyCode: 13});
+
+                ReactableTestUtils.expectRowText(0, ['Lee Salminen', '23', 'Programmer']);
+                ReactableTestUtils.expectRowText(1, ['Griffin Smith', '18', 'Engineer']);
+                ReactableTestUtils.expectRowText(2, ['Ian Zhang', '28', 'Developer']);
+
+                // Make sure the headers have the right classes
+                expect($(nameHeader)).to.have.class('reactable-header-sort-asc');
+            });
+
+            it('does not sort on non-enter keydown', function(){
+                var nameHeader = $('#table thead tr.reactable-column-header th')[0];
+                ReactTestUtils.Simulate.keyDown(nameHeader, {keyCode: 10});
+
+                ReactableTestUtils.expectRowText(0, ['Lee Salminen', '23', 'Programmer']);
+                ReactableTestUtils.expectRowText(1, ['Griffin Smith', '18', 'Engineer']);
+                ReactableTestUtils.expectRowText(2, ['Ian Zhang', '28', 'Developer']);
+
+                // Make sure the headers have the right classes
+                expect($(nameHeader)).to.have.class('reactable-header-sort-asc');
+            });
         });
 
         describe('passing `true` to sortable', function() {
@@ -1658,7 +1682,7 @@ describe('Reactable', function() {
                 ReactableTestUtils.expectRowText(2, ['Third']);
             });
         });
-    
+
         describe('sorts and calls onSort callback via props', function(){
             var sortColumn = null;
 
@@ -1678,7 +1702,7 @@ describe('Reactable', function() {
                                 // sort based on classname
                                 return a.props.className.localeCompare(b.props.className);
                             }
-                        }]} 
+                        }]}
                         onSort={ callback }/>,
                     ReactableTestUtils.testNode()
                 );


### PR DESCRIPTION
In general, really happy with the a11y features of this component so far.

I noticed that the `tabindex="0"` + `role="button"` attributes on `<th>` elements is working really inconsistently across browsers and screen readers to trigger sorting from the keyboard. Also, tab focus + hitting enter doesn't work at all when the screen reader is turned off, which isn't necessarily an a11y concern, but a little surprising given that it can receive tab focus like buttons and links.

This implements an `onKeyDown` handler in the `<Thead>` component that triggers `this.props.onSort` when the key pressed is the `enter` key. I was able to reuse the existing behavior from `handleClickTh` in addition to checking which key was pressed.

This solution works across browsers with or without a screen reader, which I think is an overall improvement to the interface.