### PR TITLE
Fix bad td label

### DIFF
--- a/build/reactable.js
+++ b/build/reactable.js
@@ -740,7 +740,7 @@ window.ReactDOM["default"] = window.ReactDOM;
                         column.props = (0, _libFilter_props_from.filterPropsFrom)(th.props);
 
                         // use the content as the label & key
-                        if (typeof th.props.children !== 'undefined') {
+                        if (typeof th.props.children === 'string') {
                             column.label = th.props.children;
                             column.key = column.label;
                         }

--- a/lib/reactable/thead.js
+++ b/lib/reactable/thead.js
@@ -121,7 +121,7 @@ var Thead = (function (_React$Component) {
                     column.props = (0, _libFilter_props_from.filterPropsFrom)(th.props);
 
                     // use the content as the label & key
-                    if (typeof th.props.children !== 'undefined') {
+                    if (typeof th.props.children === 'string') {
                         column.label = th.props.children;
                         column.key = column.label;
                     }

--- a/src/reactable/thead.jsx
+++ b/src/reactable/thead.jsx
@@ -13,7 +13,7 @@ export class Thead extends React.Component {
                 column.props = filterPropsFrom(th.props);
 
                 // use the content as the label & key
-                if (typeof th.props.children !== 'undefined') {
+                if (typeof th.props.children === 'string') {
                     column.label = th.props.children;
                     column.key = column.label;
                 }


### PR DESCRIPTION
Fix bad label when using TH children that are react components.

In this case:

```
<Thead>
  <Th column="button" column="test" style={ {  padding: 10} }>
    <strong>Test it</strong>
  </Th>
  <Th column="code">
    <strong>Description</strong>
  </Th>
</Thead>
```

I got this DOM:
![reactable bug](https://cloud.githubusercontent.com/assets/12717418/13670901/fa2910a4-e6cc-11e5-8ac5-c1d87f0bad0e.png)

Regards
