### PR TITLE
change the library name to lowercase

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "Reactable",
+  "name": "reactable",
   "version": "0.13.2",
   "main": "build/reactable.js",
   "dependencies": {


### PR DESCRIPTION

<img width="920" alt="bower_warning_screenshot" src="https://cloud.githubusercontent.com/assets/6592072/15634724/fba36866-2598-11e6-9d4a-322feda38d69.png">

```bower install``` produced an invalid meta name warning due to the capitalization of the library name in ```bower.json```. Changed the name to lowercase.

