### PR TITLE
update Td component to handle arbitrary props, remove hardcoded props

### DIFF
--- a/build/reactable.js
+++ b/build/reactable.js
@@ -394,18 +394,20 @@ window.ReactDOM["default"] = window.ReactDOM;
 
 (function (global, factory) {
     if (typeof define === 'function' && define.amd) {
-        define(['exports', 'react', './lib/is_react_component', './lib/stringable', './unsafe'], factory);
+        define(['exports', 'react', './lib/is_react_component', './lib/stringable', './unsafe', './lib/filter_props_from'], factory);
     } else if (typeof exports !== 'undefined') {
-        factory(exports, require('react'), require('./lib/is_react_component'), require('./lib/stringable'), require('./unsafe'));
+        factory(exports, require('react'), require('./lib/is_react_component'), require('./lib/stringable'), require('./unsafe'), require('./lib/filter_props_from'));
     } else {
         var mod = {
             exports: {}
         };
-        factory(mod.exports, global.React, global.is_react_component, global.stringable, global.unsafe);
+        factory(mod.exports, global.React, global.is_react_component, global.stringable, global.unsafe, global.filter_props_from);
         global.td = mod.exports;
     }
-})(this, function (exports, _react, _libIs_react_component, _libStringable, _unsafe) {
+})(this, function (exports, _react, _libIs_react_component, _libStringable, _unsafe, _libFilter_props_from) {
     'use strict';
+
+    var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
     var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
 
@@ -425,50 +427,44 @@ window.ReactDOM["default"] = window.ReactDOM;
         }
 
         _createClass(Td, [{
-            key: 'handleClick',
-            value: function handleClick(e) {
-                if (typeof this.props.handleClick === 'function') {
-                    return this.props.handleClick(e, this);
+            key: 'stringifyIfNotReactComponent',
+            value: function stringifyIfNotReactComponent(object) {
+                if (!(0, _libIs_react_component.isReactComponent)(object) && (0, _libStringable.stringable)(object) && typeof object !== 'undefined') {
+                    return object.toString();
                 }
+                return null;
             }
         }, {
             key: 'render',
             value: function render() {
-                var tdProps = {
-                    className: this.props.className,
-                    onClick: this.handleClick.bind(this)
-                };
-
-                if (typeof this.props.style !== 'undefined') {
-                    tdProps.style = this.props.style;
-                }
-
                 // Attach any properties on the column to this Td object to allow things like custom event handlers
+                var mergedProps = (0, _libFilter_props_from.filterPropsFrom)(this.props);
                 if (typeof this.props.column === 'object') {
                     for (var key in this.props.column) {
                         if (key !== 'key' && key !== 'name') {
-                            tdProps[key] = this.props.column[key];
+                            mergedProps[key] = this.props.column[key];
                         }
                     }
                 }
+                // handleClick aliases onClick event
+                mergedProps.onClick = this.props.handleClick;
 
-                var data = this.props.data;
+                var stringifiedChildProps;
 
-                if (typeof this.props.children !== 'undefined') {
-                    if ((0, _libIs_react_component.isReactComponent)(this.props.children)) {
-                        data = this.props.children;
-                    } else if (typeof this.props.data === 'undefined' && (0, _libStringable.stringable)(this.props.children)) {
-                        data = this.props.children.toString();
-                    }
-
-                    if ((0, _unsafe.isUnsafe)(this.props.children)) {
-                        tdProps.dangerouslySetInnerHTML = { __html: this.props.children.toString() };
-                    } else {
-                        tdProps.children = data;
-                    }
+                if (typeof this.props.data === 'undefined') {
+                    stringifiedChildProps = this.stringifyIfNotReactComponent(this.props.children);
                 }
 
-                return _react['default'].createElement('td', tdProps);
+                if ((0, _unsafe.isUnsafe)(this.props.children)) {
+                    return _react['default'].createElement('td', _extends({}, mergedProps, {
+                        dangerouslySetInnerHTML: { __html: this.props.children.toString() } }));
+                } else {
+                    return _react['default'].createElement(
+                        'td',
+                        mergedProps,
+                        stringifiedChildProps || this.props.children
+                    );
+                }
             }
         }]);
 

--- a/lib/reactable/td.js
+++ b/lib/reactable/td.js
@@ -4,6 +4,8 @@ Object.defineProperty(exports, '__esModule', {
     value: true
 });
 
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
 var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
 
 var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; _again = false; if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; desc = parent = undefined; continue _function; } } else if ('value' in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
@@ -24,6 +26,8 @@ var _libStringable = require('./lib/stringable');
 
 var _unsafe = require('./unsafe');
 
+var _libFilter_props_from = require('./lib/filter_props_from');
+
 var Td = (function (_React$Component) {
     _inherits(Td, _React$Component);
 
@@ -34,50 +38,44 @@ var Td = (function (_React$Component) {
     }
 
     _createClass(Td, [{
-        key: 'handleClick',
-        value: function handleClick(e) {
-            if (typeof this.props.handleClick === 'function') {
-                return this.props.handleClick(e, this);
+        key: 'stringifyIfNotReactComponent',
+        value: function stringifyIfNotReactComponent(object) {
+            if (!(0, _libIs_react_component.isReactComponent)(object) && (0, _libStringable.stringable)(object) && typeof object !== 'undefined') {
+                return object.toString();
             }
+            return null;
         }
     }, {
         key: 'render',
         value: function render() {
-            var tdProps = {
-                className: this.props.className,
-                onClick: this.handleClick.bind(this)
-            };
-
-            if (typeof this.props.style !== 'undefined') {
-                tdProps.style = this.props.style;
-            }
-
             // Attach any properties on the column to this Td object to allow things like custom event handlers
+            var mergedProps = (0, _libFilter_props_from.filterPropsFrom)(this.props);
             if (typeof this.props.column === 'object') {
                 for (var key in this.props.column) {
                     if (key !== 'key' && key !== 'name') {
-                        tdProps[key] = this.props.column[key];
+                        mergedProps[key] = this.props.column[key];
                     }
                 }
             }
+            // handleClick aliases onClick event
+            mergedProps.onClick = this.props.handleClick;
 
-            var data = this.props.data;
+            var stringifiedChildProps;
 
-            if (typeof this.props.children !== 'undefined') {
-                if ((0, _libIs_react_component.isReactComponent)(this.props.children)) {
-                    data = this.props.children;
-                } else if (typeof this.props.data === 'undefined' && (0, _libStringable.stringable)(this.props.children)) {
-                    data = this.props.children.toString();
-                }
-
-                if ((0, _unsafe.isUnsafe)(this.props.children)) {
-                    tdProps.dangerouslySetInnerHTML = { __html: this.props.children.toString() };
-                } else {
-                    tdProps.children = data;
-                }
+            if (typeof this.props.data === 'undefined') {
+                stringifiedChildProps = this.stringifyIfNotReactComponent(this.props.children);
             }
 
-            return _react2['default'].createElement('td', tdProps);
+            if ((0, _unsafe.isUnsafe)(this.props.children)) {
+                return _react2['default'].createElement('td', _extends({}, mergedProps, {
+                    dangerouslySetInnerHTML: { __html: this.props.children.toString() } }));
+            } else {
+                return _react2['default'].createElement(
+                    'td',
+                    mergedProps,
+                    stringifiedChildProps || this.props.children
+                );
+            }
         }
     }]);
 

--- a/tests/reactable_test.jsx
+++ b/tests/reactable_test.jsx
@@ -2451,7 +2451,6 @@ describe('Reactable', function() {
                 </Reactable.Table>,
                 ReactableTestUtils.testNode()
             );
-
             ReactTestUtils.Simulate.click($('td')[0])
         });
 
@@ -2460,6 +2459,33 @@ describe('Reactable', function() {
         it('calls the callbacks on click', function() {
             expect(this.clicked).to.eq(true);
         });
+    });
+
+    describe('onContextMenu callbacks on <Td> elements', function(){
+        before(function() {
+            this.rightClicked = false
+
+            ReactDOM.render(
+                <Reactable.Table className="table" id="table">
+                    <Reactable.Tr>
+                        <Reactable.Td column="Name" onContextMenu={function() {
+                            this.rightClicked = true;
+                        }.bind(this)}>
+                            <b>Griffin Smith</b>
+                        </Reactable.Td>
+                    </Reactable.Tr>
+                </Reactable.Table>,
+                ReactableTestUtils.testNode()
+            );
+            ReactTestUtils.Simulate.contextMenu($('td')[0])
+        });
+
+        after(ReactableTestUtils.resetTestEnvironment);
+
+        it('calls the callbacks on right click', function() {
+            expect(this.rightClicked).to.eq(true);
+        });
+
     });
 
     describe('table with no data', () => {


### PR DESCRIPTION
The Td component no longer uses the `TdProps` object, instead using filteredProps. I'm not super-familiar with this library, so I kept the `handleClick` prop on the Td component, although people should just use `onClick` probably.

Fixes #255.