### PR TITLE
checking for undefined in nextProps so we don't clear out the current page

### DIFF
--- a/build/reactable.js
+++ b/build/reactable.js
@@ -1250,7 +1250,7 @@ window.ReactDOM["default"] = window.ReactDOM;
         }, {
             key: 'updateCurrentPage',
             value: function updateCurrentPage(nextPage) {
-                if (nextPage !== this.state.currentPage) {
+                if (typeof nextPage !== 'undefined' && nextPage !== this.state.currentPage) {
                     this.setState({ currentPage: nextPage });
                 }
             }

--- a/lib/reactable/table.js
+++ b/lib/reactable/table.js
@@ -281,7 +281,7 @@ var Table = (function (_React$Component) {
     }, {
         key: 'updateCurrentPage',
         value: function updateCurrentPage(nextPage) {
-            if (nextPage !== this.state.currentPage) {
+            if (typeof nextPage !== 'undefined' && nextPage !== this.state.currentPage) {
                 this.setState({ currentPage: nextPage });
             }
         }

--- a/src/reactable/table.jsx
+++ b/src/reactable/table.jsx
@@ -240,7 +240,7 @@ export class Table extends React.Component {
     }
 
     updateCurrentPage(nextPage) {
-        if (nextPage !== this.state.currentPage) {
+        if (typeof(nextPage) !== 'undefined' && nextPage !== this.state.currentPage) {
             this.setState({ currentPage: nextPage});
         }
     }

--- a/tests/reactable_test.jsx
+++ b/tests/reactable_test.jsx
@@ -2580,4 +2580,35 @@ describe('Reactable', function() {
         });
       });
     })
+
+    describe('receive props with no currentPage', () => {
+        let parent;
+
+        before(function () {
+            //create a wrapper component so we can update its state and trigger componentWillReceiveProps in the table
+            var TestParent = React.createFactory(React.createClass({
+                render() {
+                    return (<Reactable.Table className="table" id="table" ref="table">
+                        <Reactable.Tr>
+                            <Reactable.Td column="Name">
+                                <b>Griffin Smith</b>
+                            </Reactable.Td>
+                        </Reactable.Tr>
+                    </Reactable.Table>);
+                }
+            }));
+
+            parent = ReactDOM.render(TestParent(), ReactableTestUtils.testNode());
+        });
+
+        after(ReactableTestUtils.resetTestEnvironment);
+
+        it('keeps the same currentPage and does not set it to undefined', function() {
+            const preUpdateCurrentPage  = parent.refs.table.state.currentPage;
+            parent.setState({testState: "this state update will trigger componentWillReceiveProps in the Reactable.Table"});
+            const postUpdateCurrentPage  = parent.refs.table.state.currentPage;
+            expect(postUpdateCurrentPage).to.not.eq(undefined);
+            expect(postUpdateCurrentPage).to.eq(preUpdateCurrentPage);
+        });
+    });
 });


### PR DESCRIPTION
539dc9202e03287d0f378024ad19b09c630582a7 added a currentPage prop that introduced a subtle bug. When componentWillReceiveProps is called without a currentPage prop, the state for currentPage was set to undefined, which then fails in paginator.jsx with "Must pass a currentPage argument to Paginator".

By leaving the state alone when the currentPage prop isn't present, we avoid this failure.