### PR TITLE
allow user to display a custom component when table has no children

### DIFF
--- a/build/reactable.js
+++ b/build/reactable.js
@@ -1025,6 +1025,8 @@ window.ReactDOM["default"] = window.ReactDOM;
 
     var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; _again = false; if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; desc = parent = undefined; continue _function; } } else if ('value' in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
 
+    function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
+
     function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
     function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
@@ -1051,6 +1053,8 @@ window.ReactDOM["default"] = window.ReactDOM;
                 var sortingColumn = props.sortBy || props.defaultSort;
                 this.state.currentSort = this.getCurrentSort(sortingColumn);
             }
+
+            this.renderNoDataComponent = this.renderNoDataComponent.bind(this);
         }
 
         _createClass(Table, [{
@@ -1391,6 +1395,26 @@ window.ReactDOM["default"] = window.ReactDOM;
                 }
             }
         }, {
+            key: 'renderNoDataComponent',
+            value: function renderNoDataComponent(columns) {
+                var noDataFunc = this.props.noDataComponent;
+                if (typeof noDataFunc === 'function') {
+                    return noDataFunc(columns);
+                } else if (this.props.noDataText) {
+                    return _react['default'].createElement(
+                        'tr',
+                        { className: 'reactable-no-data' },
+                        _react['default'].createElement(
+                            'td',
+                            { colSpan: columns.length },
+                            this.props.noDataText
+                        )
+                    );
+                } else {
+                    return null;
+                }
+            }
+        }, {
             key: 'render',
             value: function render() {
                 var _this = this;
@@ -1498,17 +1522,12 @@ window.ReactDOM["default"] = window.ReactDOM;
                 }
 
                 // Manually transfer props
-                var props = (0, _libFilter_props_from.filterPropsFrom)(this.props);
 
-                var noDataText = this.props.noDataText ? _react['default'].createElement(
-                    'tr',
-                    { className: 'reactable-no-data' },
-                    _react['default'].createElement(
-                        'td',
-                        { colSpan: columns.length },
-                        this.props.noDataText
-                    )
-                ) : null;
+                var _filterPropsFrom = (0, _libFilter_props_from.filterPropsFrom)(this.props);
+
+                var noDataComponent = _filterPropsFrom.noDataComponent;
+
+                var props = _objectWithoutProperties(_filterPropsFrom, ['noDataComponent']);
 
                 var tableHeader = null;
                 if (columns && columns.length > 0 && showHeaders) {
@@ -1535,7 +1554,7 @@ window.ReactDOM["default"] = window.ReactDOM;
                     _react['default'].createElement(
                         'tbody',
                         { className: 'reactable-data', key: 'tbody' },
-                        currentChildren.length > 0 ? currentChildren : noDataText
+                        currentChildren.length > 0 ? currentChildren : this.renderNoDataComponent(columns)
                     ),
                     pagination === true ? _react['default'].createElement(_paginator.Paginator, { colSpan: columns.length,
                         pageButtonLimit: pageButtonLimit,
@@ -1567,6 +1586,17 @@ window.ReactDOM["default"] = window.ReactDOM;
         itemsPerPage: 0,
         filterBy: '',
         hideFilterInput: false
+    };
+
+    Table.propTypes = {
+        sortBy: _react['default'].PropTypes.bool,
+        itemsPerPage: _react['default'].PropTypes.number, // number of items to display per page
+        filterable: _react['default'].PropTypes.array, // columns to look at when applying the filter specified by filterBy
+        filterBy: _react['default'].PropTypes.string, // text to filter the results by (see filterable)
+        hideFilterInput: _react['default'].PropTypes.bool, // Whether the default input field for the search/filter should be hidden or not
+        hideTableHeader: _react['default'].PropTypes.bool, // Whether the table header should be hidden or not
+        noDataText: _react['default'].PropTypes.string, // Text to be displayed in the event there is no data to show
+        noDataComponent: _react['default'].PropTypes.func // function called to provide a component to display in the event there is no data to show (supercedes noDataText)
     };
 });
 

--- a/lib/reactable/table.js
+++ b/lib/reactable/table.js
@@ -12,6 +12,8 @@ var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_ag
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
+function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
+
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
 function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
@@ -58,6 +60,8 @@ var Table = (function (_React$Component) {
             var sortingColumn = props.sortBy || props.defaultSort;
             this.state.currentSort = this.getCurrentSort(sortingColumn);
         }
+
+        this.renderNoDataComponent = this.renderNoDataComponent.bind(this);
     }
 
     _createClass(Table, [{
@@ -398,6 +402,26 @@ var Table = (function (_React$Component) {
             }
         }
     }, {
+        key: 'renderNoDataComponent',
+        value: function renderNoDataComponent(columns) {
+            var noDataFunc = this.props.noDataComponent;
+            if (typeof noDataFunc === 'function') {
+                return noDataFunc(columns);
+            } else if (this.props.noDataText) {
+                return _react2['default'].createElement(
+                    'tr',
+                    { className: 'reactable-no-data' },
+                    _react2['default'].createElement(
+                        'td',
+                        { colSpan: columns.length },
+                        this.props.noDataText
+                    )
+                );
+            } else {
+                return null;
+            }
+        }
+    }, {
         key: 'render',
         value: function render() {
             var _this = this;
@@ -505,17 +529,12 @@ var Table = (function (_React$Component) {
             }
 
             // Manually transfer props
-            var props = (0, _libFilter_props_from.filterPropsFrom)(this.props);
 
-            var noDataText = this.props.noDataText ? _react2['default'].createElement(
-                'tr',
-                { className: 'reactable-no-data' },
-                _react2['default'].createElement(
-                    'td',
-                    { colSpan: columns.length },
-                    this.props.noDataText
-                )
-            ) : null;
+            var _filterPropsFrom = (0, _libFilter_props_from.filterPropsFrom)(this.props);
+
+            var noDataComponent = _filterPropsFrom.noDataComponent;
+
+            var props = _objectWithoutProperties(_filterPropsFrom, ['noDataComponent']);
 
             var tableHeader = null;
             if (columns && columns.length > 0 && showHeaders) {
@@ -542,7 +561,7 @@ var Table = (function (_React$Component) {
                 _react2['default'].createElement(
                     'tbody',
                     { className: 'reactable-data', key: 'tbody' },
-                    currentChildren.length > 0 ? currentChildren : noDataText
+                    currentChildren.length > 0 ? currentChildren : this.renderNoDataComponent(columns)
                 ),
                 pagination === true ? _react2['default'].createElement(_paginator.Paginator, { colSpan: columns.length,
                     pageButtonLimit: pageButtonLimit,
@@ -574,4 +593,15 @@ Table.defaultProps = {
     itemsPerPage: 0,
     filterBy: '',
     hideFilterInput: false
+};
+
+Table.propTypes = {
+    sortBy: _react2['default'].PropTypes.bool,
+    itemsPerPage: _react2['default'].PropTypes.number, // number of items to display per page
+    filterable: _react2['default'].PropTypes.array, // columns to look at when applying the filter specified by filterBy
+    filterBy: _react2['default'].PropTypes.string, // text to filter the results by (see filterable)
+    hideFilterInput: _react2['default'].PropTypes.bool, // Whether the default input field for the search/filter should be hidden or not
+    hideTableHeader: _react2['default'].PropTypes.bool, // Whether the table header should be hidden or not
+    noDataText: _react2['default'].PropTypes.string, // Text to be displayed in the event there is no data to show
+    noDataComponent: _react2['default'].PropTypes.func // function called to provide a component to display in the event there is no data to show (supercedes noDataText)
 };

--- a/src/reactable/table.jsx
+++ b/src/reactable/table.jsx
@@ -26,6 +26,8 @@ export class Table extends React.Component {
             let sortingColumn = props.sortBy || props.defaultSort;
             this.state.currentSort = this.getCurrentSort(sortingColumn);
         }
+
+        this.renderNoDataComponent = this.renderNoDataComponent.bind(this);
     }
 
     filterBy(filter) {
@@ -355,6 +357,17 @@ export class Table extends React.Component {
         }
     }
 
+    renderNoDataComponent(columns) {
+        let noDataFunc = this.props.noDataComponent;
+        if (typeof noDataFunc === 'function') {
+            return noDataFunc(columns);
+        } else if (this.props.noDataText) {
+            return <tr className="reactable-no-data"><td colSpan={columns.length}>{this.props.noDataText}</td></tr>;
+        } else {
+            return null;
+        }
+    }
+
     render() {
         let children = [];
         let columns;
@@ -476,9 +489,7 @@ export class Table extends React.Component {
         }
 
         // Manually transfer props
-        let props = filterPropsFrom(this.props);
-
-        let noDataText = this.props.noDataText ? <tr className="reactable-no-data"><td colSpan={columns.length}>{this.props.noDataText}</td></tr> : null;
+        let { noDataComponent, ...props } = filterPropsFrom(this.props);
 
         var tableHeader = null;
         if (columns && columns.length > 0 && showHeaders) {
@@ -503,7 +514,7 @@ export class Table extends React.Component {
         return <table {...props}>
             {tableHeader}
             <tbody className="reactable-data" key="tbody">
-                {currentChildren.length > 0 ? currentChildren : noDataText}
+                {currentChildren.length > 0 ? currentChildren : this.renderNoDataComponent(columns)}
             </tbody>
             {pagination === true ?
              <Paginator colSpan={columns.length}
@@ -532,4 +543,15 @@ Table.defaultProps = {
     itemsPerPage: 0,
     filterBy: '',
     hideFilterInput: false
+};
+
+Table.propTypes = {
+    sortBy: React.PropTypes.bool,
+    itemsPerPage: React.PropTypes.number,               // number of items to display per page
+    filterable: React.PropTypes.array,                  // columns to look at when applying the filter specified by filterBy
+    filterBy: React.PropTypes.string,                   // text to filter the results by (see filterable)
+    hideFilterInput: React.PropTypes.bool,              // Whether the default input field for the search/filter should be hidden or not
+    hideTableHeader: React.PropTypes.bool,              // Whether the table header should be hidden or not
+    noDataText: React.PropTypes.string,                 // Text to be displayed in the event there is no data to show
+    noDataComponent: React.PropTypes.func               // function called to provide a component to display in the event there is no data to show (supercedes noDataText)
 };

--- a/tests/reactable_test.jsx
+++ b/tests/reactable_test.jsx
@@ -2639,7 +2639,54 @@ describe('Reactable', function() {
           expect(text).to.eq('No matching records found.');
         });
       });
+      context('when filtered without any matches', () => {
+          before(function() {
+            let noDataComponent = (columns) => {
+                return <tr><td colSpan={columns.length}>Showing custom NoData component.</td></tr>
+            };
 
+            this.component = ReactDOM.render(
+                <Reactable.Table className="table" id="table"
+                                 filterable={['State', 'Tag']}
+                                 filterPlaceholder="Filter Results"
+                                 filterBy='xxxxx'
+                                 noDataComponent={noDataComponent}
+                                 noDataText="No matching records found."
+                                 columns={['State', 'Description', 'Tag']}>
+                    <Reactable.Tr>
+                        <Reactable.Td column='State'>New York</Reactable.Td>
+                        <Reactable.Td column='Description'>this is some text</Reactable.Td>
+                        <Reactable.Td column='Tag'>new</Reactable.Td>
+                    </Reactable.Tr>
+                    <Reactable.Tr>
+                        <Reactable.Td column='State'>New Mexico</Reactable.Td>
+                        <Reactable.Td column='Description'>lorem ipsum</Reactable.Td>
+                        <Reactable.Td column='Tag'>old</Reactable.Td>
+                    </Reactable.Tr>
+                    <Reactable.Tr>
+                        <Reactable.Td column='State'>Colorado</Reactable.Td>
+                        <Reactable.Td column='Description'>
+                            new description that shouldnt match filter
+                        </Reactable.Td>
+                        <Reactable.Td column='Tag'>old</Reactable.Td>
+                    </Reactable.Tr>
+                    <Reactable.Tr>
+                        <Reactable.Td column='State'>Alaska</Reactable.Td>
+                        <Reactable.Td column='Description'>bacon</Reactable.Td>
+                        <Reactable.Td column='Tag'>renewed</Reactable.Td>
+                    </Reactable.Tr>
+                </Reactable.Table>,
+                ReactableTestUtils.testNode()
+            );
+          });
+
+          after(ReactableTestUtils.resetTestEnvironment);
+
+          it('shows the "no data" message from the component function', () => {
+              var text = $('table > tbody > tr').text();
+              expect(text).to.eq('Showing custom NoData component.');
+          });
+      });
       context('when initialized with an empty array for `data` prop', () => {
         before(function() {
             this.component = ReactDOM.render(


### PR DESCRIPTION
I would love a way to display a custom component when there's no data to show in the table rather than just text. 

Hoping this pull request can at least start the discussion, or, if it looks good, provide the solution. Open to any input.
