### PR TITLE
Pass column props pulled from header to <Td>s.

### DIFF
--- a/build/reactable.js
+++ b/build/reactable.js
@@ -513,6 +513,8 @@ window.ReactDOM["default"] = window.ReactDOM;
 
     var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_again) { var object = _x, property = _x2, receiver = _x3; _again = false; if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x = parent; _x2 = property; _x3 = receiver; _again = true; desc = parent = undefined; continue _function; } } else if ('value' in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
 
+    function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
+
     function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
     function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
@@ -536,10 +538,14 @@ window.ReactDOM["default"] = window.ReactDOM;
                         console.log(children);
                     }
 
-                    children = children.concat(this.props.columns.map((function (column, i) {
+                    children = children.concat(this.props.columns.map((function (_ref, i) {
+                        var _ref$props = _ref.props;
+                        var props = _ref$props === undefined ? {} : _ref$props;
+
+                        var column = _objectWithoutProperties(_ref, ['props']);
+
                         if (this.props.data.hasOwnProperty(column.key)) {
                             var value = this.props.data[column.key];
-                            var props = {};
 
                             if (typeof value !== 'undefined' && value !== null && value.__reactableMeta === true) {
                                 props = value.props;

--- a/lib/reactable/tr.js
+++ b/lib/reactable/tr.js
@@ -12,6 +12,8 @@ var _get = function get(_x, _x2, _x3) { var _again = true; _function: while (_ag
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
 
+function _objectWithoutProperties(obj, keys) { var target = {}; for (var i in obj) { if (keys.indexOf(i) >= 0) continue; if (!Object.prototype.hasOwnProperty.call(obj, i)) continue; target[i] = obj[i]; } return target; }
+
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
 function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
@@ -45,10 +47,14 @@ var Tr = (function (_React$Component) {
                     console.log(children);
                 }
 
-                children = children.concat(this.props.columns.map((function (column, i) {
+                children = children.concat(this.props.columns.map((function (_ref, i) {
+                    var _ref$props = _ref.props;
+                    var props = _ref$props === undefined ? {} : _ref$props;
+
+                    var column = _objectWithoutProperties(_ref, ['props']);
+
                     if (this.props.data.hasOwnProperty(column.key)) {
                         var value = this.props.data[column.key];
-                        var props = {};
 
                         if (typeof value !== 'undefined' && value !== null && value.__reactableMeta === true) {
                             props = value.props;

--- a/src/reactable/tr.jsx
+++ b/src/reactable/tr.jsx
@@ -14,10 +14,9 @@ export class Tr extends React.Component {
         ) {
             if (typeof(children.concat) === 'undefined') { console.log(children); }
 
-            children = children.concat(this.props.columns.map(function(column, i) {
+            children = children.concat(this.props.columns.map(function({ props = {}, ...column}, i) {
                 if (this.props.data.hasOwnProperty(column.key)) {
                     var value = this.props.data[column.key];
-                    var props = {};
 
                     if (
                         typeof(value) !== 'undefined' &&


### PR DESCRIPTION
This should fix #311 I think, if I understand the intentions correctly. 

At [this point](https://github.com/glittershark/reactable/blob/master/src/reactable/tr.jsx#L20), each column being mapped over already has a `props` property passed down from when the column is retrieved [from the header](https://github.com/glittershark/reactable/blob/master/src/reactable/thead.jsx#L13).

I'm [now using](https://github.com/ericf89/reactable/blob/master/src/reactable/tr.jsx#L17...L19) those header props instead of creating a new empty object.  
