### PR TITLE
persist filter across table refreshes

### DIFF
--- a/build/reactable.js
+++ b/build/reactable.js
@@ -1257,6 +1257,11 @@ window.ReactDOM["default"] = window.ReactDOM;
                 };
             }
         }, {
+            key: 'getCurrentFilter',
+            value: function getCurrentFilter(propFilter) {
+                return this.state.filter !== undefined && propFilter === '' ? this.state.filter : propFilter;
+            }
+        }, {
             key: 'updateCurrentSort',
             value: function updateCurrentSort(sortBy) {
                 if (sortBy !== false && sortBy.column !== this.state.currentSort.column && sortBy.direction !== this.state.currentSort.direction) {
@@ -1279,13 +1284,20 @@ window.ReactDOM["default"] = window.ReactDOM;
                 this.filterBy(this.props.filterBy);
             }
         }, {
+            key: 'getCurrentFilter',
+            value: function getCurrentFilter(propFilter) {
+                return this.state.filter !== undefined && propFilter === '' ? this.state.filter : propFilter;
+            }
+        }, {
             key: 'componentWillReceiveProps',
             value: function componentWillReceiveProps(nextProps) {
                 this.initialize(nextProps);
                 this.updateCurrentPage(nextProps.currentPage);
                 this.updateCurrentSort(nextProps.sortBy);
                 this.sortByCurrentSort();
-                this.filterBy(nextProps.filterBy);
+
+                var filter = this.getCurrentFilter(nextProps.filterBy);
+                this.filterBy(filter);
             }
         }, {
             key: 'applyFilter',

--- a/lib/reactable/table.js
+++ b/lib/reactable/table.js
@@ -271,6 +271,11 @@ var Table = (function (_React$Component) {
             };
         }
     }, {
+        key: 'getCurrentFilter',
+        value: function getCurrentFilter(propFilter) {
+            return this.state.filter !== undefined && propFilter === '' ? this.state.filter : propFilter;
+        }
+    }, {
         key: 'updateCurrentSort',
         value: function updateCurrentSort(sortBy) {
             if (sortBy !== false && sortBy.column !== this.state.currentSort.column && sortBy.direction !== this.state.currentSort.direction) {
@@ -293,13 +298,20 @@ var Table = (function (_React$Component) {
             this.filterBy(this.props.filterBy);
         }
     }, {
+        key: 'getCurrentFilter',
+        value: function getCurrentFilter(propFilter) {
+            return this.state.filter !== undefined && propFilter === '' ? this.state.filter : propFilter;
+        }
+    }, {
         key: 'componentWillReceiveProps',
         value: function componentWillReceiveProps(nextProps) {
             this.initialize(nextProps);
             this.updateCurrentPage(nextProps.currentPage);
             this.updateCurrentSort(nextProps.sortBy);
             this.sortByCurrentSort();
-            this.filterBy(nextProps.filterBy);
+
+            var filter = this.getCurrentFilter(nextProps.filterBy);
+            this.filterBy(filter);
         }
     }, {
         key: 'applyFilter',

--- a/src/reactable/table.jsx
+++ b/src/reactable/table.jsx
@@ -230,6 +230,12 @@ export class Table extends React.Component {
         };
     }
 
+    getCurrentFilter(propFilter) {
+        return (this.state.filter !== undefined && propFilter === '') ?
+            this.state.filter :
+            propFilter;
+    }
+
     updateCurrentSort(sortBy) {
         if (sortBy !== false &&
             sortBy.column !== this.state.currentSort.column &&
@@ -251,12 +257,20 @@ export class Table extends React.Component {
         this.filterBy(this.props.filterBy);
     }
 
+    getCurrentFilter(propFilter) {
+        return (this.state.filter !== undefined && propFilter === '') ?
+            this.state.filter :
+            propFilter;
+    }
+
     componentWillReceiveProps(nextProps) {
         this.initialize(nextProps);
         this.updateCurrentPage(nextProps.currentPage)
         this.updateCurrentSort(nextProps.sortBy);
         this.sortByCurrentSort();
-        this.filterBy(nextProps.filterBy);
+
+        let filter = this.getCurrentFilter(nextProps.filterBy);
+        this.filterBy(filter);
     }
 
     applyFilter(filter, children) {


### PR DESCRIPTION
addresses #215 
If a filter is currently applied, and new filter props aren't being passed into the Table during a table refresh, re-use the filter from the existing state.