### PR TITLE
checking if !th in thead.jsx

### DIFF
--- a/build/reactable.js
+++ b/build/reactable.js
@@ -752,6 +752,7 @@ window.ReactDOM["default"] = window.ReactDOM;
                 var columns = [];
                 _react['default'].Children.forEach(component.props.children, function (th) {
                     var column = {};
+                    if (!th) return;
                     if (typeof th.props !== 'undefined') {
                         column.props = (0, _libFilter_props_from.filterPropsFrom)(th.props);
 

--- a/lib/reactable/thead.js
+++ b/lib/reactable/thead.js
@@ -120,6 +120,7 @@ var Thead = (function (_React$Component) {
             var columns = [];
             _react2['default'].Children.forEach(component.props.children, function (th) {
                 var column = {};
+                if (!th) return;
                 if (typeof th.props !== 'undefined') {
                     column.props = (0, _libFilter_props_from.filterPropsFrom)(th.props);
 

--- a/src/reactable/thead.jsx
+++ b/src/reactable/thead.jsx
@@ -9,6 +9,7 @@ export class Thead extends React.Component {
         let columns = [];
         React.Children.forEach(component.props.children, th => {
             var column = {};
+            if (!th) return;
             if (typeof th.props !== 'undefined') {
                 column.props = filterPropsFrom(th.props);
 

--- a/tests/reactable_test.jsx
+++ b/tests/reactable_test.jsx
@@ -375,6 +375,26 @@ describe('Reactable', function() {
                 ReactableTestUtils.expectRowText(1, ['', '28', 'Developer']);
             });
         });
+
+        context("when one of the <Th>s is null", function(){
+            before(function () {
+                ReactDOM.render(
+                    <Reactable.Table className="table" id="table">
+                      <Reactable.Thead>
+                        <Reactable.Th>Test</Reactable.Th>
+                        {null}
+                      </Reactable.Thead>
+                    </Reactable.Table>,
+                    ReactableTestUtils.testNode()
+                );
+            });
+
+          after(ReactableTestUtils.resetTestEnvironment);
+
+          it('renders the table', function() {
+              expect($('table#table.table')).to.exist;
+          });
+        });
     });
 
     describe('Adding a <Tfoot>', function() {


### PR DESCRIPTION
Given a component with conditional columns like this:

```jsx
import { Table, Thead, Th, Tr, Td } from 'reactable';
import React, { Component } from 'react';
import './App.css';

class App extends Component {
  constructor(props) {
    super(props);

    this.state = {
      show: true
    };

    this._handleClick = this._handleClick.bind(this);
  }

  render() {
    return (
      <div className="App">
        <button onClick={this._handleClick}>Toggle</button>
        <Table>
          <Thead>
            <Th column="always">Always Header</Th>
            {this._renderConditionalHeader()}
          </Thead>
          <Tr>
            <Td column="always">always here</Td>
            {this._renderConditionalData()}
          </Tr>
        </Table>
      </div>
    );
  }

  _renderConditionalHeader() {
    if (!this.state.show) return null;
    return <Th column="conditional">Conditional Header</Th>;
  }

  _renderConditionalData() {
    if (!this.state.show) return null;
    return <Td column="conditional">conditionally here</Td>;
  }

  _handleClick() {
    this.setState({
      show: !this.state.show
    });
  }
}

export default App;
```

Toggling `state.show` to `false` results in this error in the console:

```
thead.js:123 Uncaught TypeError: Cannot read property 'props' of null(…)(anonymous function) @ thead.js:123forEachSingleChild @ ReactChildren.js:52traverseAllChildrenImpl @ traverseAllChildren.js:69traverseAllChildrenImpl @ traverseAllChildren.js:85traverseAllChildren @ traverseAllChildren.js:164forEachChildren @ ReactChildren.js:72getColumns @ thead.js:121render @ table.js:421(anonymous function) @ ReactCompositeComponent.js:793measureLifeCyclePerf @ ReactCompositeComponent.js:74_renderValidatedComponentWithoutOwnerOrContext @ ReactCompositeComponent.js:792_renderValidatedComponent @ ReactCompositeComponent.js:819_updateRenderedComponent @ ReactCompositeComponent.js:743_performComponentUpdate @ ReactCompositeComponent.js:721updateComponent @ ReactCompositeComponent.js:642receiveComponent @ ReactCompositeComponent.js:544receiveComponent @ ReactReconciler.js:126updateChildren @ ReactChildReconciler.js:110_reconcilerUpdateChildren @ ReactMultiChild.js:210_updateChildren @ ReactMultiChild.js:314updateChildren @ ReactMultiChild.js:301_updateDOMChildren @ ReactDOMComponent.js:942updateComponent @ ReactDOMComponent.js:760receiveComponent @ ReactDOMComponent.js:718receiveComponent @ ReactReconciler.js:126_updateRenderedComponent @ ReactCompositeComponent.js:751_performComponentUpdate @ ReactCompositeComponent.js:721updateComponent @ ReactCompositeComponent.js:642performUpdateIfNecessary @ ReactCompositeComponent.js:558performUpdateIfNecessary @ ReactReconciler.js:158runBatchedUpdates @ ReactUpdates.js:151perform @ Transaction.js:138perform @ Transaction.js:138perform @ ReactUpdates.js:90flushBatchedUpdates @ ReactUpdates.js:173closeAll @ Transaction.js:204perform @ Transaction.js:151batchedUpdates @ ReactDefaultBatchingStrategy.js:63batchedUpdates @ ReactUpdates.js:98dispatchEvent @ ReactEventListener.js:150
```

 I'm pretty sure this happens whenever a child of `<Thead>` is `null`. 

This proposed fix checks if `th` is not a falsey value before adding it to the `columns` array.