### PR TITLE
add defaultSortFunction

### DIFF
--- a/build/reactable.js
+++ b/build/reactable.js
@@ -30,6 +30,7 @@ window.ReactDOM["default"] = window.ReactDOM;
         sort: true,
         sortBy: true,
         sortableColumns: true,
+        defaultSortFunction: true,
         onSort: true,
         defaultSort: true,
         defaultSortDescending: true,
@@ -1337,32 +1338,29 @@ window.ReactDOM["default"] = window.ReactDOM;
                 }
 
                 this.data.sort((function (a, b) {
-                    var keyA = (0, _libExtract_data_from.extractDataFrom)(a, currentSort.column);
+                    var keyA = (0, _libExtract_data_from.extractDataFrom)(currentSort.direction === 1 ? a : b, currentSort.column);
                     keyA = (0, _unsafe.isUnsafe)(keyA) ? keyA.toString() : keyA || '';
-                    var keyB = (0, _libExtract_data_from.extractDataFrom)(b, currentSort.column);
+                    var keyB = (0, _libExtract_data_from.extractDataFrom)(currentSort.direction === 1 ? b : a, currentSort.column);
                     keyB = (0, _unsafe.isUnsafe)(keyB) ? keyB.toString() : keyB || '';
 
-                    // Default sort
                     if (typeof this._sortable[currentSort.column] === 'undefined' || this._sortable[currentSort.column] === 'default') {
+                        if (typeof this.props.defaultSortFunction !== 'undefined') {
+                            return this.props.defaultSortFunction(keyA, keyB);
+                        }
 
-                        // Reverse direction if we're doing a reverse sort
+                        // Default sort
                         if (keyA < keyB) {
-                            return -1 * currentSort.direction;
+                            return -1;
                         }
 
                         if (keyA > keyB) {
-                            return 1 * currentSort.direction;
+                            return 1;
                         }
 
                         return 0;
-                    } else {
-                        // Reverse columns if we're doing a reverse sort
-                        if (currentSort.direction === 1) {
-                            return this._sortable[currentSort.column](keyA, keyB);
-                        } else {
-                            return this._sortable[currentSort.column](keyB, keyA);
-                        }
                     }
+
+                    return this._sortable[currentSort.column](keyA, keyB);
                 }).bind(this));
             }
         }, {

--- a/lib/reactable/lib/filter_props_from.js
+++ b/lib/reactable/lib/filter_props_from.js
@@ -18,6 +18,7 @@ var internalProps = {
     sort: true,
     sortBy: true,
     sortableColumns: true,
+    defaultSortFunction: true,
     onSort: true,
     defaultSort: true,
     defaultSortDescending: true,

--- a/lib/reactable/table.js
+++ b/lib/reactable/table.js
@@ -344,32 +344,29 @@ var Table = (function (_React$Component) {
             }
 
             this.data.sort((function (a, b) {
-                var keyA = (0, _libExtract_data_from.extractDataFrom)(a, currentSort.column);
+                var keyA = (0, _libExtract_data_from.extractDataFrom)(currentSort.direction === 1 ? a : b, currentSort.column);
                 keyA = (0, _unsafe.isUnsafe)(keyA) ? keyA.toString() : keyA || '';
-                var keyB = (0, _libExtract_data_from.extractDataFrom)(b, currentSort.column);
+                var keyB = (0, _libExtract_data_from.extractDataFrom)(currentSort.direction === 1 ? b : a, currentSort.column);
                 keyB = (0, _unsafe.isUnsafe)(keyB) ? keyB.toString() : keyB || '';
 
-                // Default sort
                 if (typeof this._sortable[currentSort.column] === 'undefined' || this._sortable[currentSort.column] === 'default') {
+                    if (typeof this.props.defaultSortFunction !== 'undefined') {
+                        return this.props.defaultSortFunction(keyA, keyB);
+                    }
 
-                    // Reverse direction if we're doing a reverse sort
+                    // Default sort
                     if (keyA < keyB) {
-                        return -1 * currentSort.direction;
+                        return -1;
                     }
 
                     if (keyA > keyB) {
-                        return 1 * currentSort.direction;
+                        return 1;
                     }
 
                     return 0;
-                } else {
-                    // Reverse columns if we're doing a reverse sort
-                    if (currentSort.direction === 1) {
-                        return this._sortable[currentSort.column](keyA, keyB);
-                    } else {
-                        return this._sortable[currentSort.column](keyB, keyA);
-                    }
                 }
+
+                return this._sortable[currentSort.column](keyA, keyB);
             }).bind(this));
         }
     }, {

--- a/src/reactable/lib/filter_props_from.jsx
+++ b/src/reactable/lib/filter_props_from.jsx
@@ -12,6 +12,7 @@ const internalProps = {
     sort: true,
     sortBy: true,
     sortableColumns: true,
+    defaultSortFunction: true,
     onSort: true,
     defaultSort: true,
     defaultSortDescending: true,

--- a/src/reactable/table.jsx
+++ b/src/reactable/table.jsx
@@ -299,35 +299,32 @@ export class Table extends React.Component {
         }
 
         this.data.sort(function(a, b){
-            let keyA = extractDataFrom(a, currentSort.column);
+            let keyA = extractDataFrom(currentSort.direction === 1 ? a : b, currentSort.column);
             keyA = isUnsafe(keyA) ? keyA.toString() : keyA || '';
-            let keyB = extractDataFrom(b, currentSort.column);
+            let keyB = extractDataFrom(currentSort.direction === 1 ? b : a, currentSort.column);
             keyB = isUnsafe(keyB) ? keyB.toString() : keyB || '';
 
-            // Default sort
             if (
                 typeof(this._sortable[currentSort.column]) === 'undefined' ||
                     this._sortable[currentSort.column] === 'default'
             ) {
+                if (typeof this.props.defaultSortFunction !== 'undefined') {
+                  return this.props.defaultSortFunction(keyA, keyB);
+                }
 
-                // Reverse direction if we're doing a reverse sort
+                // Default sort
                 if (keyA < keyB) {
-                    return -1 * currentSort.direction;
+                    return -1;
                 }
 
                 if (keyA > keyB) {
-                    return 1 * currentSort.direction;
+                    return 1;
                 }
 
                 return 0;
-            } else {
-                // Reverse columns if we're doing a reverse sort
-                if (currentSort.direction === 1) {
-                    return this._sortable[currentSort.column](keyA, keyB);
-                } else {
-                    return this._sortable[currentSort.column](keyB, keyA);
-                }
             }
+
+            return this._sortable[currentSort.column](keyA, keyB);
         }.bind(this));
     }
 


### PR DESCRIPTION
AFAIK, there's no mechanism to override default sorting function in https://github.com/glittershark/reactable/blob/master/src/reactable/table.jsx#L311. This becomes a problem if for example, the column names are not known (generated dynamically), but client needs to pass a custom sorting function.

I need this for a project. I figured it might be useful for other people as well. Feel free to close PR if that's not the case.