### PR TITLE
prevent handleClick prop from making it to rendered component

### DIFF
--- a/build/reactable.js
+++ b/build/reactable.js
@@ -466,6 +466,9 @@ window.ReactDOM["default"] = window.ReactDOM;
                 // handleClick aliases onClick event
                 mergedProps.onClick = this.props.handleClick;
 
+                // remove property to avoid unknown prop warning
+                delete mergedProps.handleClick;
+
                 var stringifiedChildProps;
 
                 if (typeof this.props.data === 'undefined') {

--- a/lib/reactable/td.js
+++ b/lib/reactable/td.js
@@ -60,6 +60,9 @@ var Td = (function (_React$Component) {
             // handleClick aliases onClick event
             mergedProps.onClick = this.props.handleClick;
 
+            // remove property to avoid unknown prop warning
+            delete mergedProps.handleClick;
+
             var stringifiedChildProps;
 
             if (typeof this.props.data === 'undefined') {

--- a/src/reactable/td.jsx
+++ b/src/reactable/td.jsx
@@ -25,6 +25,9 @@ export class Td extends React.Component {
         // handleClick aliases onClick event
         mergedProps.onClick = this.props.handleClick;
 
+        // remove property to avoid unknown prop warning
+        delete mergedProps.handleClick;
+
         var stringifiedChildProps;
 
         if (typeof(this.props.data) === 'undefined') {


### PR DESCRIPTION
During render of a `Td` component, the handleClick property is (understandably) not removed from the props during the filter stage. Alas, it makes it as an attribute to the <td> element, resulting in the react 15+ warning:

`Warning: Unknown prop 'handleClick' on <td> tag. Remove this prop from the element. `

At some point, I imagine it'd be best to deprecate handleClick in favor of onClick, but until then...

