### PR TITLE
Adding the ability to use complex forms in filters

### DIFF
--- a/build/reactable.js
+++ b/build/reactable.js
@@ -1314,7 +1314,11 @@ window.ReactDOM["default"] = window.ReactDOM;
                                 }
                             } else {
                                 // Apply custom filter
-                                if (this._filterable[filterColumn]((0, _libExtract_data_from.extractDataFrom)(data, filterColumn).toString(), filter)) {
+                                var rawData = (0, _libExtract_data_from.extractDataFrom)(data, filterColumn);
+                                if (rawData.toString() !== '[object Object]') {
+                                    rawData = rawData.toString();
+                                }
+                                if (this._filterable[filterColumn](rawData, filter)) {
                                     matchedChildren.push(children[i]);
                                     break;
                                 }

--- a/lib/reactable/table.js
+++ b/lib/reactable/table.js
@@ -321,7 +321,11 @@ var Table = (function (_React$Component) {
                             }
                         } else {
                             // Apply custom filter
-                            if (this._filterable[filterColumn]((0, _libExtract_data_from.extractDataFrom)(data, filterColumn).toString(), filter)) {
+                            var rawData = (0, _libExtract_data_from.extractDataFrom)(data, filterColumn);
+                            if (rawData.toString() !== '[object Object]') {
+                                rawData = rawData.toString();
+                            }
+                            if (this._filterable[filterColumn](rawData, filter)) {
                                 matchedChildren.push(children[i]);
                                 break;
                             }

--- a/src/reactable/table.jsx
+++ b/src/reactable/table.jsx
@@ -277,7 +277,11 @@ export class Table extends React.Component {
                         }
                     } else {
                         // Apply custom filter
-                        if (this._filterable[filterColumn](extractDataFrom(data, filterColumn).toString(), filter)) {
+                        let rawData = extractDataFrom(data, filterColumn);
+                        if (rawData.toString() !== '[object Object]') {
+                            rawData = rawData.toString();
+                        }
+                        if (this._filterable[filterColumn](rawData, filter)) {
                             matchedChildren.push(children[i]);
                             break;
                         }

--- a/tests/reactable_test.jsx
+++ b/tests/reactable_test.jsx
@@ -2421,6 +2421,60 @@ describe('Reactable', function() {
                 });
             });
         });
+
+
+        context('with custom filter and complex contents', function() {
+            before(function() {
+                this.component = ReactDOM.render(
+                    <Reactable.Table className="table" id="table"
+                        filterable={[
+                            {
+                                column: 'State',
+                                filterFunction: function(contents, filter) {
+                                    return (
+                                        typeof(contents) !== 'undefined' && typeof(filter) !== 'undefined' &&
+                                        contents.props.value.toLowerCase().indexOf(filter) > -1
+                                    );
+                                },
+                            }
+                        ]}
+                        filterPlaceholder="Filter Results"
+                        columns={['State', 'Description', 'Tag']}>
+                        <Reactable.Tr>
+                            <Reactable.Td column='State'><div value="NY">New York</div></Reactable.Td>
+                            <Reactable.Td column='Description'>this is some text</Reactable.Td>
+                            <Reactable.Td column='Tag'>new</Reactable.Td>
+                        </Reactable.Tr>
+                        <Reactable.Tr>
+                            <Reactable.Td column='State'><div value="NM">New Mexico</div></Reactable.Td>
+                            <Reactable.Td column='Description'>lorem ipsum</Reactable.Td>
+                            <Reactable.Td column='Tag'>old x</Reactable.Td>
+                        </Reactable.Tr>
+                        <Reactable.Tr>
+                            <Reactable.Td column='State'><div value="CO">Colorado</div></Reactable.Td>
+                            <Reactable.Td column='Description'>lol</Reactable.Td>
+                            <Reactable.Td column='Tag'>renewed x</Reactable.Td>
+                        </Reactable.Tr>
+                        <Reactable.Tr>
+                            <Reactable.Td column='State'><div value="AK">Alaska</div></Reactable.Td>
+                            <Reactable.Td column='Description'>bacon</Reactable.Td>
+                            <Reactable.Td column='Tag'>new</Reactable.Td>
+                        </Reactable.Tr>
+                    </Reactable.Table>,
+                    ReactableTestUtils.testNode()
+                );
+
+                this.component.filterBy('AK');
+            });
+
+            after(ReactableTestUtils.resetTestEnvironment);
+
+            it('filters based on a prop specified in the custom filter', function() {
+                ReactableTestUtils.expectRowText(0, ['Alaska', 'bacon', 'new']);
+            });
+        });
+
+
     });
 
     describe('directly passing a data array with non-string data', function() {


### PR DESCRIPTION
This change allows the user to put more complex formatting into the table (e.g. React components) and still filter the table based on those rows.

Currently, while the custom sort functions are fed the raw contents of each cell (& so get react components directly if they're being used), the filter functions get a stringified version, meaning everything gets filtered against `[object Object]`, which is not especially useful. This tries to preserve all current use cases, but in the event that `toString()` returns `[object Object]`, it sends the object (presumably a React component, though it could be something complex within the data array.)